### PR TITLE
Expand roadmap with forward-looking vision

### DIFF
--- a/docs/roadmap/compiler.md
+++ b/docs/roadmap/compiler.md
@@ -1,0 +1,236 @@
+# Compiler Module Plans
+
+Each module plan includes objectives, detailed tasks, dependencies, and exit criteria. Work through the modules roughly in the order listed; later stages assume the prior ones are code-complete and tested.
+
+## 1. Lexer & Token Infrastructure (`src/lexer.rs`, `src/token.rs`)
+
+**Objectives**
+- Produce a streaming lexer that tokenizes UTF-8 source with precise span data.
+- Support incremental re-lexing for IDE tooling.
+
+**Step-by-step plan**
+1. Catalogue keywords, operators, and literal forms based on the 10-construct minimal surface.
+2. Implement a zero-copy cursor over byte slices with explicit error tokens for malformed UTF-8 and unterminated literals.
+3. Attach `Span { file_id, offset, len }` metadata to every token.
+4. Expose an incremental entry point `fn relex(range: ByteRange)` that yields token replacements for the editor pipeline.
+5. Write snapshot tests covering:
+   - Numeric literal edges (underscores, hex, binary, floats without integer parts).
+   - Nested block comments and doc comments.
+   - Capability annotations (`!{io, net}`) and `using` scopes.
+
+**Dependencies**
+- None; this is the bootstrap stage.
+
+**Exit Criteria**
+- `cargo test -p lexer` (or equivalent module tests) passes with 95%+ branch coverage for token classification.
+- CLI mode `mica --tokens` renders spans and lexemes for sample programs.
+
+**Future-facing trajectory**
+- Enrich doc-comment handling to feed future doc generators and literate tooling.
+- Expose token change deltas over language-server channels to support collaborative editing and remote builds.
+- Prepare for capability-sensitive lexing (e.g., gated keywords) by isolating feature flags in the token catalogue.
+
+## 2. Parser & AST (`src/parser.rs`, `src/ast.rs`)
+
+**Objectives**
+- Maintain a hand-written recursive-descent parser with Pratt expression parsing.
+- Produce a recoverable AST suitable for formatting and tooling.
+
+**Step-by-step plan**
+1. Map the grammar into AST enums/structs, including effect rows, `using` blocks, trait bounds, and task constructs.
+2. Implement Pratt precedence tables for arithmetic, comparison, logical, and pipeline operators (if added later).
+3. Add single-token insertion/deletion recovery hooks so downstream phases still run.
+4. Support a lossless mode that retains comments/whitespace for pretty-printing.
+5. Expand parser tests:
+   - Round-trip snapshots (`parse` -> `pretty` -> `parse`) to guarantee idempotence.
+   - Error-recovery fixtures verifying diagnostic quality (expected tokens, inserted tokens).
+
+**Dependencies**
+- Lexer tokens and spans.
+
+**Exit Criteria**
+- `mica --ast --pretty` matches golden files in `tests/parse_snapshots`.
+- Parser can continue after at least 3 representative syntax errors.
+
+**Future-facing trajectory**
+- Power AST-driven refactoring bots by expanding the lossless tree with stable node IDs.
+- Enable partial parsing for on-device development (low-memory) by formalizing chunked parse boundaries.
+- Keep the grammar adaptable for future features like effect handlers or deterministic async sugar without breaking recoverability.
+
+## 3. Resolver (`src/resolve.rs`)
+
+**Objectives**
+- Build symbol tables for modules, types, values, traits, and capabilities.
+- Track effect aliases and import visibility.
+
+**Step-by-step plan**
+1. Implement a two-phase resolver: declaration collection, then use resolution.
+2. Model nested modules with lexical scopes, supporting `use` + aliasing.
+3. Track capabilities/effect rows so we can flag missing capability parameters early.
+4. Emit IDE-friendly lookup structures (symbol IDs + spans) shared with the LSP server.
+5. Add tests covering shadowing, cross-module imports, and capability alias resolution.
+
+**Dependencies**
+- Parser AST.
+
+**Exit Criteria**
+- `mica --resolve` emits symbol graphs for examples.
+- Name resolution handles at least two modules with cyclic `use` patterns (erroring gracefully).
+
+**Future-facing trajectory**
+- Persist symbol graphs for “explain this code” tooling and governance audits.
+- Provide streaming symbol updates to the LSP to unlock large-workspace scaling.
+- Keep capability resolution modular so future capability providers (GPU, AI, ledger) plug in cleanly.
+
+## 4. Type & Effect Checker (`src/check.rs`)
+
+**Objectives**
+- Perform Hindley–Milner inference with trait constraints and row polymorphism.
+- Enforce move semantics, borrow rules, and capability usage.
+
+**Step-by-step plan**
+1. Implement unification that supports record and effect-row extension.
+2. Add trait solving with coherence checks (Rust-like orphan rules) and dictionary passing for codegen.
+3. Track ownership transitions: moves, `&` borrows, `&mut` exclusivity, and `using` drop scopes.
+4. Integrate capability verification: ensure functions consuming effects receive appropriate parameters.
+5. Produce structured diagnostics with suggestions (`add using`, `pass io capability`).
+6. Build regression tests for borrow errors, trait resolution, and effect mismatches.
+
+**Dependencies**
+- Resolver symbol tables.
+
+**Exit Criteria**
+- `mica --check` succeeds on all examples and fails with actionable diagnostics on crafted negative tests.
+- Borrow checker forbids use-after-move in integration tests.
+
+**Future-facing trajectory**
+- Record proof artifacts (constraints, capability flows) for optional verification/attestation pipelines.
+- Expose effect constraints to optimization passes for deterministic scheduling research.
+- Structure diagnostics so future assistants can propose verified fixes without guessing intent.
+
+## 5. Lowering & Intermediate Representation (`src/lower.rs`, `src/ir/*`)
+
+**Objectives**
+- Lower typed AST into an SSA-like IR annotated with effects.
+- Prepare ground for LLVM code generation and optimization.
+
+**Step-by-step plan**
+1. Design the IR data model (modules, functions, basic blocks, effect metadata) under `src/ir/`.
+2. Translate expressions/statements into SSA form with phi nodes and explicit resource drops.
+3. Mark pure regions to enable deterministic auto-parallelization of `par` constructs.
+4. Emit textual dumps for debugging (`mica --lower --pretty`).
+5. Seed optimization passes: dead code elimination, effect-aware inlining guards.
+6. Write lowering tests that compare IR snapshots for representative language features.
+
+**Dependencies**
+- Type-checked AST.
+
+**Exit Criteria**
+- IR snapshot tests live in `tests/lower_snapshots` and pass.
+- Pure-region analysis recognizes at least loops/functions without effect rows.
+
+**Future-facing trajectory**
+- Tag IR nodes with provenance so auto-tuners can relate runtime metrics back to source constructs.
+- Keep effect metadata first-class to experiment with deterministic distributed execution.
+- Design IR serialization for future incremental compilation and remote caching services.
+
+## 6. Backend & Runtime Interface (`src/backend/*`, `runtime/`)
+
+**Objectives**
+- Generate machine code via LLVM.
+- Provide runtime shims for capabilities (IO, Net, Time) and task scheduling.
+
+**Step-by-step plan**
+1. Scaffold `src/backend/llvm.rs` with module/function emitters.
+2. Map capability usage to runtime calls; define `runtime/` crate for host services.
+3. Implement deterministic scheduler for structured tasks, respecting cancellation semantics.
+4. Hook build pipeline into `mica build` CLI command.
+5. Add integration tests using `cargo test -p runtime` and golden output tests (`mica run examples/...`).
+
+**Dependencies**
+- Stable IR and effect annotations.
+
+**Exit Criteria**
+- Simple programs (hello world, parallel sum) compile to native binaries and run.
+- Capability misuse at runtime produces structured errors, not panics.
+
+**Future-facing trajectory**
+- Allow backend substitution (e.g., MLIR, WASM) without reworking lowering semantics.
+- Instrument runtime hooks for deterministic replay and time-travel debugging.
+- Define capability provider interfaces that third parties can implement safely.
+
+## 7. Formatter & Pretty Printer (`src/pretty.rs`)
+
+**Objectives**
+- Provide deterministic formatting consistent with the grammar and style guide.
+- Support both full-file formatting and range formatting for editor support.
+
+**Step-by-step plan**
+1. Define formatting rules for declarations, match arms, effect rows, and nested `using` blocks.
+2. Implement a concrete syntax tree (CST) facade around the lossless parser mode.
+3. Provide `fmt::Session` APIs for whole-file and range-based formatting.
+4. Build idempotence tests: format -> format again -> diff == empty.
+5. Integrate with CLI (`mica fmt`) and expose `--check` mode for CI.
+
+**Dependencies**
+- Lossless parser.
+
+**Exit Criteria**
+- `mica fmt` runs on the repo without diffs after the second pass.
+- Range-format tests cover typical IDE scenarios (format selection, single function).
+
+**Future-facing trajectory**
+- Share formatting primitives with lint and auto-refactor tools to keep automation trustworthy.
+- Surface “format with intent” options for generated code or tutorials without drifting from canonical style.
+- Lay groundwork for effect-aware diff minimization (only rewrite regions impacted by diagnostics).
+
+## 8. Command-Line Interface (`src/bin/mica.rs`, `src/main.rs`)
+
+**Objectives**
+- Expose compiler stages via subcommands.
+- Provide diagnostics and exit codes suitable for CI.
+
+**Step-by-step plan**
+1. Implement subcommands: `tokens`, `ast`, `resolve`, `check`, `lower`, `fmt`, `build`, `run`.
+2. Share a pipeline builder that caches intermediate results between subcommands.
+3. Add JSON output option for integration with editors and build tools.
+4. Write CLI snapshot tests using `assert_cmd` for success and failure modes.
+
+**Dependencies**
+- Underlying compiler modules.
+
+**Exit Criteria**
+- CLI docs (`docs/snippets.md`) are generated automatically and verified in CI.
+- Non-zero exit codes propagate for diagnostic failures.
+
+**Future-facing trajectory**
+- Offer daemon mode for build servers and cloud IDEs to minimize cold-start costs.
+- Provide declarative pipelines so organizations can extend the CLI without forking.
+- Integrate with future governance tooling (e.g., compile with RFC gating) via structured command metadata.
+
+## 9. Testing & Quality Infrastructure (`tests/`, `xtask/`)
+
+**Objectives**
+- Ensure broad coverage and reproducibility across compiler modules.
+
+**Step-by-step plan**
+1. Stand up `xtask` utilities for snapshot regeneration and fixture scaffolding.
+2. Introduce code coverage reporting via `cargo llvm-cov` in CI.
+3. Automate fuzzing hooks for lexer/parser (`cargo fuzz` integration).
+4. Document testing strategy in `docs/roadmap/tooling.md`.
+
+**Dependencies**
+- Cross-cutting; evolves with modules.
+
+**Exit Criteria**
+- CI pipeline enforces formatting, clippy, tests, coverage threshold, and snippet freshness.
+- Fuzzers execute nightly with budgeted runtime.
+
+**Future-facing trajectory**
+- Publish anonymized diagnostic telemetry (opt-in) to inform language design and documentation.
+- Automate bisecting of fuzz failures with deterministic reproduction harnesses.
+- Expose coverage gaps to the roadmap so planning stays data-driven.
+
+---
+
+*Last updated: keep this date aligned with the latest roadmap revisions.*

--- a/docs/roadmap/ecosystem.md
+++ b/docs/roadmap/ecosystem.md
@@ -1,0 +1,80 @@
+# Ecosystem & Interop Strategy
+
+The language succeeds only if developers can build real systems today and still feel ahead of the curve tomorrow. This plan
+focuses on libraries, package distribution, and interoperability tracks that future-proof the ecosystem.
+
+## Standard Library Growth
+
+| Wave | Focus | Modules | Notes |
+| --- | --- | --- | --- |
+| S0 | Core primitives | `core::{Option, Result, List, Vec, Iterator}`, numeric traits, `String`, `Bytes`. | Stabilize APIs; ensure zero allocations in iterator adapters when possible. |
+| S1 | Systems access | `sys::{fs, net, time, process}`, structured tasks, channel abstractions. | Respect capability boundaries; design async-friendly IO wrappers. |
+| S2 | Data tooling | `data::{csv, json, arrow}`, streaming parsers, schema inference. | Provide iterators instead of full materialization; integrate with `mica::io` traits. |
+| S3 | Numerics | `math::{vec, mat, linalg}`, BLAS-backed ops with safe fallbacks. | Expose GPU hooks via capability gating (`!{gpu}`). |
+| S4 | Concurrency extras | `concurrent::{Mutex, RwLock, Actor}` for rare escape hatches. | Document determinism trade-offs and effect requirements. |
+
+**Exit Criteria**
+- Each wave has API docs, usage guides, and examples under `examples/`.
+- Benchmarks show parity with equivalent Rust implementations within 10% for targeted workloads.
+
+**Future-facing trajectory**
+- Stage later waves (S5+) for privacy-preserving analytics, GPU/AI accelerators, and verifiable computation helpers.
+- Publish stability levels so downstream teams can adopt modules with clear upgrade cadences.
+- Link benchmarking harnesses to roadmap analytics for ongoing performance governance.
+
+## Package Manager & Registry
+
+1. Specify `mica.toml` manifest (targets, dependencies, capabilities) in `docs/specs/mica_toml.md`.
+2. Build `mica package` CLI:
+   - `mica package init`, `add`, `remove`, `update`.
+   - Lockfile format with deterministic resolution.
+3. Stand up hosted index prototype (S3 + CDN) with signed package manifests.
+4. Document publishing workflow, including capability audits and lint gates.
+
+**Exit Criteria**
+- Sample workspace with two packages builds and runs via `mica build`.
+- Publishing dry-run validates signatures and manifest schema.
+
+**Future-facing trajectory**
+- Support reproducible builds via content-addressed storage and optional attestations.
+- Allow capability declarations in manifests to drive security reviews and automated policy checks.
+- Explore decentralized mirrors with deterministic conflict resolution for global teams.
+
+## Interoperability Tracks
+
+1. **C ABI**: Provide `mica cbindgen` command to emit headers, plus runtime tests linking C callers.
+2. **Python/JavaScript Foreign Tasks**:
+   - Design message boundary protocol (JSON / Arrow) and isolation runtime.
+   - Implement adapters in `crates/mica-foreign-{python,js}`.
+   - Supply examples bridging to Pandas/Node streams.
+3. **Rust & TypeScript Migration**:
+   - Build transpiler prototypes for common subsets (iterators, ADTs).
+   - Provide migration guides in `docs/migration/`.
+
+**Exit Criteria**
+- At least one end-to-end demo calling Python data processing from Mica with deterministic boundaries.
+- Interop docs detail safety guarantees and limitations (no shared mutable state, explicit capabilities).
+
+**Future-facing trajectory**
+- Expand foreign-task adapters to structured AI workloads with auditable prompts/results.
+- Provide schema-aware bridges (Arrow Flight, gRPC) with deterministic serialization strategies.
+- Prototype dual-language debugging sessions where Mica and the host runtime share effect traces.
+
+## Community & Governance
+
+1. Publish contribution guidelines, RFC template, and governance document (`docs/GOVERNANCE.md`).
+2. Establish RFC process: stage proposals, shepherds, decision logs.
+3. Schedule community sync (monthly) and office hours (bi-weekly) once repo is public.
+
+**Exit Criteria**
+- First three RFCs (effect system, task runtime, package manager) processed end-to-end.
+- Governance doc ratified by core team.
+
+**Future-facing trajectory**
+- Establish contributor ladders that recognize design, implementation, and stewardship equally.
+- Automate RFC history linking into IDE hints (e.g., “this feature originated in RFC-12”).
+- Build mentorship and residency programs to cultivate future compiler implementers.
+
+---
+
+_Track updates quarterly alongside roadmap reviews._

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,0 +1,13 @@
+# Mica Implementation Roadmap
+
+This directory captures the actionable plans that turn the language vision into a working toolchain while keeping an eye on the
+next decade of language design. It is organized into:
+
+- [`compiler.md`](compiler.md) — deep dives for each compiler module with deliverables, dependencies, and risk notes.
+- [`tooling.md`](tooling.md) — CLI, formatter, IDE/LSP, and developer-experience milestones.
+- [`ecosystem.md`](ecosystem.md) — standard library growth, package management, and interoperability tracks.
+- [`milestones.md`](milestones.md) — the chronological playbook that stitches everything together into ship-ready phases.
+
+Every file closes with explicit exit criteria **and** forward-looking signals so we know when a phase is complete and whether
+we’re still aligned with the long-term vision. Keep these documents in sync with the codebase; treat them as the living “source
+of truth” for planning and language research.

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -1,0 +1,99 @@
+# Phased Execution Milestones
+
+This playbook sequences the workstreams so we can ship usable artifacts after each phase and keep sight of the longer-term
+language vision. Each milestone includes entry prerequisites, core work items, exit criteria, and the forward-looking signals we
+should observe before moving on.
+
+## Phase 0 — Foundations
+
+- **Entry**: Vision, language sketch, and module plans approved.
+- **Work Items**:
+  1. Finalize lexer/token spec and parser AST schemas.
+  2. Set up repo scaffolding: `cargo` workspace layout, CI skeleton, coding standards.
+  3. Implement lexer with unit tests and CLI `--tokens` mode.
+  4. Implement parser with snapshot tests and error recovery skeleton.
+- **Exit**:
+  - Parser successfully round-trips all examples.
+  - CI runs lint + unit tests on every PR.
+  - **Future signal**: Prototype language playground can lex/parse snippets in-browser using shared components.
+
+## Phase 1 — Semantic Core
+
+- **Entry**: Phase 0 exit criteria satisfied.
+- **Work Items**:
+  1. Build resolver with symbol tables and IDE-friendly spans.
+  2. Implement Hindley–Milner inference, trait solving, and borrow checker.
+  3. Enforce effect capability rules; craft negative tests.
+  4. Publish diagnostics style guide and update CLI outputs.
+- **Exit**:
+  - `mica --check examples/*` passes (positive suite) and fails with actionable messages (negative suite).
+  - Borrow checker prohibits use-after-move in integration tests.
+  - **Future signal**: Constraint graphs export cleanly for potential verification tooling.
+
+## Phase 2 — Intermediate Representation
+
+- **Entry**: Type checker stabilizes, diagnostics accepted by DX team.
+- **Work Items**:
+  1. Design SSA-like IR (`src/ir/`); document structure.
+  2. Lower typed AST to IR, tracking drops and effect metadata.
+  3. Implement IR printer + snapshot tests.
+  4. Prototype purity analysis for `par` loops and structured tasks.
+- **Exit**:
+  - Lowering snapshot suite covers control flow, pattern matching, effects, and tasks.
+  - Purity analysis identifies effect-free regions on sample programs.
+  - **Future signal**: IR contains enough provenance to correlate with runtime traces.
+
+## Phase 3 — Backend & Runtime
+
+- **Entry**: IR lowering stable, tests passing.
+- **Work Items**:
+  1. Hook IR into LLVM backend, producing native binaries.
+  2. Build runtime crate with capability shims (IO, Net, Time, Task scheduler).
+  3. Implement deterministic task runtime with cancellation semantics.
+  4. Provide `mica build` and `mica run` commands.
+- **Exit**:
+  - Hello-world, CSV aggregate, and parallel sum examples compile & run with deterministic results.
+  - Runtime errors surface as structured diagnostics, not panics.
+  - **Future signal**: Backend abstractions demonstrate feasibility of targeting WASM/MLIR without major rewrites.
+
+## Phase 4 — Tooling & IDE
+
+- **Entry**: Backend emits working binaries; runtime is stable.
+- **Work Items**:
+  1. Ship formatter (`mica fmt`) and linter framework.
+  2. Build LSP server with hover, go-to-definition, diagnostics, and code actions.
+  3. Generate CLI docs and integrate into mdBook site.
+  4. Harden testing infrastructure (coverage, fuzzing, xtask automation).
+- **Exit**:
+  - VS Code extension demo validated with live editing session.
+  - CI enforces fmt, lint, tests, docs, coverage.
+  - **Future signal**: LSP emits capability flow data consumable by future auditing tools.
+
+## Phase 5 — Ecosystem Launch
+
+- **Entry**: Tooling is developer-friendly; docs pipeline stable.
+- **Work Items**:
+  1. Release standard library waves S0–S2 with docs + examples.
+  2. Build package manager MVP (`mica package`, registry prototype).
+  3. Publish interop adapters (C ABI, Python, JS) with end-to-end demos.
+  4. Finalize governance and community processes.
+- **Exit**:
+  - Public beta announcement with downloadable toolchain.
+  - First external contributors ship PRs using documented workflow.
+  - **Future signal**: Registry telemetry shows capability usage patterns to guide next-wave stdlib work.
+
+## Phase 6 — Growth & Feedback Loops
+
+- **Entry**: Ecosystem launched.
+- **Work Items**:
+  1. Expand standard library (waves S3–S4) and optional GPU capability.
+  2. Collect telemetry (opt-in) on compiler performance & diagnostics clarity.
+  3. Iterate on ergonomics based on RFC backlog; prioritize effect-system learnability.
+- **Exit**:
+  - Quarterly roadmap review produces updated documents in this folder.
+  - Adoption metrics tracked (downloads, RFC throughput, issue burn-down).
+  - **Future signal**: Community feeds verified case studies back into governance and roadmap updates.
+
+---
+
+_Update this document whenever milestones shift or new phases appear._

--- a/docs/roadmap/tooling.md
+++ b/docs/roadmap/tooling.md
@@ -1,0 +1,98 @@
+# Tooling & Developer Experience Plan
+
+This plan covers everything around the core compiler that improves day-to-day ergonomics while laying a foundation for
+automation-heavy, next-decade developer workflows.
+
+## Command-Line Interface Enhancements
+
+| Stage | Deliverable | Details | Owner |
+| --- | --- | --- | --- |
+| T1 | Unified subcommand interface | Replace ad-hoc flags with `mica <command>` verbs. Share pipeline caches and diagnostics renderer. | Compiler team |
+| T2 | JSON output surfaces | Emit machine-readable diagnostics (`--json`), AST dumps, and IR dumps for integration tests. | Compiler + DX |
+| T3 | Project manifest support | Parse `mica.toml`, resolve package graph, invoke compiler per target. Introduce `mica check`, `mica build`, `mica run`. | Build systems |
+| T4 | Scripting hooks | Allow `mica run --watch` and custom pipeline steps for codegen/formatting. | DX |
+
+**Acceptance Criteria**
+- CLI returns structured exit codes (0 success, 1 diagnostics, 2 internal errors).
+- Snapshot tests in `tests/cli/` cover both text and JSON output.
+
+**Future-facing trajectory**
+- Run the CLI in watch/daemon modes for remote build farms and cloud editors.
+- Emit provenance metadata so CI/CD systems can attest to which compiler phases ran.
+- Allow declarative pipelines that enterprises can extend with capability gates.
+
+## Formatter & Linter
+
+1. Document canonical style in `docs/style.md` (indentation, trailing commas, effect row ordering).
+2. Implement formatter (`mica fmt`) per `compiler.md` plan.
+3. Introduce lint framework with passes:
+   - Unused capability parameters.
+   - Non-exhaustive `match` on closed enums.
+   - Blocking calls inside `!{nondet}` functions.
+4. Add `mica lint --allow`/`--deny` CLI for toggling rules.
+
+**Acceptance Criteria**
+- Formatting is idempotent (CI ensures zero diff on second run).
+- Lint warnings integrate with JSON diagnostics and can be suppressed via `#[allow(rule)]` attributes (parser support required).
+
+**Future-facing trajectory**
+- Share lint facts with the checker so the language can one day offer machine-verified rewrites.
+- Support “explain this lint” documentation linking to governance-approved style rationales.
+- Provide partial-formatting strategies optimized for pair-programming or literate programming contexts.
+
+## Language Server Protocol (LSP)
+
+1. Stand up `crates/mica-lsp/` using `tower-lsp`.
+2. Wire resolver/type-checker to provide:
+   - Hover (type + effect info).
+   - Go-to-definition / references.
+   - Diagnostics with ranges.
+   - Code actions (insert `using`, add missing capability parameter).
+3. Support incremental analysis using resolver’s incremental hooks.
+4. Add range formatting and on-type formatting using formatter engine.
+5. Integrate with VS Code extension stub (`editors/vscode/`).
+
+**Acceptance Criteria**
+- `code --enable-proposed-api mica` extension demo works on sample workspace.
+- LSP integration tests simulate editing sessions and assert diagnostics churn stays under 100ms per change.
+
+**Future-facing trajectory**
+- Stream semantic graphs to collaborative IDEs for multi-user editing.
+- Surface capability flow visualizations so teams can audit effect usage live.
+- Expose language-server plugins that experiment with deterministic AI copilots without compromising safety.
+
+## Documentation Workflow
+
+1. Maintain single-source docs under `docs/` with `mdbook` or `mkdocs` (decide in T1).
+2. Auto-generate CLI reference (`mica --help` -> Markdown) and embed in docs build.
+3. Publish architecture notes from `compiler.md` as part of the docs site.
+4. Provide “playground” instructions for running snippets.
+
+**Acceptance Criteria**
+- `cargo xtask doc` builds the site locally.
+- Deployment pipeline pushes docs on main branch updates.
+
+**Future-facing trajectory**
+- Generate traceable docs (linking code, tests, roadmap) for compliance-heavy environments.
+- Embed runnable sandboxes backed by deterministic task runtimes.
+- Enable custom doc “lenses” (security, performance, pedagogy) derived from roadmap metadata.
+
+## Testing Infrastructure
+
+1. Add `cargo llvm-cov` support and enforce coverage thresholds.
+2. Wire fuzzers: `cargo fuzz run lexer` and `cargo fuzz run parser` on nightly schedule.
+3. Provide regression suite harness for effect system edge cases.
+4. Document triage process for test flakes (see `docs/CONTRIBUTING.md`).
+
+**Acceptance Criteria**
+- CI matrix runs tests, fmt, lint, coverage, fuzz smoke, docs.
+- Nightly pipeline reports coverage/fuzz metrics to Slack.
+
+**Future-facing trajectory**
+- Feed telemetry into roadmap dashboards for data-driven prioritization.
+- Provide self-healing workflows (auto-open issues, attach reduced repros) when fuzzers crash.
+- Experiment with prover-assisted regression tests for the effect system and borrow checker.
+
+---
+
+_Last updated alongside `compiler.md`._


### PR DESCRIPTION
## Summary
- expand the README with a forward-looking language vision that links the present design to future capabilities
- add future-facing trajectory notes to the compiler, tooling, ecosystem, and milestone roadmaps while clarifying step-by-step plans
- highlight forward-looking signals and research hypotheses throughout the roadmap index and supporting docs

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d9cb7e3a908330a663eb45500bf159