### PR TITLE
Support cross-module resolution

### DIFF
--- a/docs/roadmap/next-step.md
+++ b/docs/roadmap/next-step.md
@@ -3,26 +3,55 @@
 After reviewing the existing documentation and source layout, the project has
 solid coverage of the Phase 0 goals: the lexer, parser, pretty printer, and CLI
 (`mica --tokens`, `--ast`, `--pretty`, `--resolve`, `--lower`) are implemented
-with snapshot-style tests. The resolver was recently expanded to collect
-declarations, maintain scoped symbol tables, capture imports, and record
-capability requirements, giving us the groundwork needed for the rest of Phase 1
-semantics. 【F:src/semantics/resolve.rs†L1-L390】
+with snapshot-style tests. The resolver is now split into a declaration
+collection pass and a scoped resolver. The collector seeds module-level symbol
+tables, imports, and algebraic data type metadata, while the resolver walks the
+AST to bind paths and capability annotations into those tables. This gives us
+the groundwork needed for the rest of the Phase 1 semantics. 【F:src/semantics/resolve/collector.rs†L6-L114】【F:src/semantics/resolve/resolver.rs†L9-L205】
 
 The remaining semantic layer still has notable gaps:
 
-* `resolve::resolve_module` does not yet validate unresolved paths, surface
-  diagnostics for duplicate bindings, or load cross-module dependencies.
-  Extending it toward multi-module analysis will be necessary for the compiler
-  CLI and LSP to scale. 【F:src/semantics/resolve.rs†L392-L701】
+* `resolve_module` only gathers local symbols before resolving in-module
+  references. Unresolved paths simply record `None`, and there is currently no
+  surface for duplicate-definition diagnostics or loading the targets of
+  `use` items from other files. Extending this toward cross-module analysis will
+  be necessary for the compiler CLI and future LSP support to scale. 【F:src/semantics/resolve/mod.rs†L1-L21】【F:src/semantics/resolve/resolver.rs†L206-L314】
 * `check::check_exhaustiveness` is limited to match exhaustiveness warnings and
   does not yet perform Hindley–Milner inference, borrow checking, or
-  capability/effect validation. 【F:src/semantics/check.rs†L1-L92】
+  capability/effect validation. 【F:src/semantics/check.rs†L1-L147】
 
-**Recommendation**: Begin the type and effect checker implementation. Start by
-consuming the resolver’s symbol tables to build an environment for function and
-type declarations, add capability validation hooks, and incrementally introduce
-type inference for function bodies. As that machinery grows, fold in
-cross-module resolution and diagnostics so the resolver can flag missing imports
-and duplicate definitions ahead of type checking. This lines up with the Phase 1
-plan in the compiler roadmap and positions the project for richer diagnostics
-and IDE integrations. 【F:docs/roadmap/compiler.md†L41-L130】
+## Recommended next steps
+
+1. **Harden the resolver for multi-module work.**
+   * Extend the collector to persist per-module import metadata in a form that
+     other files can consume, building a module graph that feeds follow-up
+     resolution passes. 【F:src/semantics/resolve/collector.rs†L6-L114】
+   * Teach `Resolver::resolve_path` to emit diagnostics when bindings are
+     missing or duplicated once cross-module lookups are wired in; capture spans
+     so the CLI and future LSP consumers can highlight errors precisely.
+     【F:src/semantics/resolve/resolver.rs†L31-L205】【F:src/semantics/resolve/resolver.rs†L206-L314】
+   * Add regression tests (single-file and synthetic multi-module fixtures) that
+     exercise shadowing, duplicate definitions, and `use` re-exports before
+     evolving the type checker.
+
+2. **Bootstrap the type and effect checker.**
+   * Define type environments sourced from the resolver’s symbol tables and
+     begin unification plumbing for expressions, producing placeholder type IDs
+     that later lowering stages can consume. 【F:src/semantics/check.rs†L1-L147】
+   * Add capability validation hooks that reuse the resolver’s capability
+     bindings so exhaustiveness and capability diagnostics flow through a single
+     entry point.
+   * Iterate with golden tests driven via `mica --check` to ensure early
+     regressions are caught and to document the desired diagnostic UX.
+
+3. **Align roadmap artifacts and tooling.**
+   * Update the compiler roadmap once the resolver/type-checker milestones above
+     land so the broader plan reflects real module boundaries and exit criteria.
+     【F:docs/roadmap/compiler.md†L60-L110】
+   * Promote the new resolver and checker stages through the CLI by wiring
+     `--resolve` and `--check` outputs into example fixtures, ensuring people
+     experimenting with the language see up-to-date capabilities.
+
+These steps keep progress focused on Phase 1 priorities while clearing the most
+visible gaps that block richer diagnostics and editor integrations. They also
+feed directly into the roadmap’s planned type-and-effect workstreams.

--- a/src/semantics/resolve/data.rs
+++ b/src/semantics/resolve/data.rs
@@ -88,3 +88,10 @@ pub enum CapabilityScope {
         type_name: String,
     },
 }
+
+#[derive(Debug, Clone, Default)]
+pub struct ModuleExports {
+    pub values: HashMap<String, SymbolInfo>,
+    pub types: HashMap<String, SymbolInfo>,
+    pub variants: HashMap<String, SymbolInfo>,
+}

--- a/src/semantics/resolve/mod.rs
+++ b/src/semantics/resolve/mod.rs
@@ -2,6 +2,7 @@ mod collector;
 mod data;
 mod resolver;
 mod scope;
+mod workspace;
 
 pub use data::*;
 
@@ -9,14 +10,52 @@ use crate::syntax::ast::Module;
 
 use collector::ModuleSymbols;
 use resolver::Resolver;
+use workspace::ModuleGraph;
+
+use std::collections::HashMap;
 
 pub fn resolve_module(module: &Module) -> Resolved {
+    let mut graph = ModuleGraph::new();
     let ModuleSymbols {
         module_scope,
         resolved,
-    } = collector::collect_module(module);
+        ..
+    } = graph.add_module(module);
 
-    let mut resolver = Resolver::new(module, module_scope, resolved);
+    let mut resolver = Resolver::new(module, module_scope, resolved, &graph);
     resolver.resolve();
     resolver.into_resolved()
+}
+
+pub fn resolve_modules<'a, I>(modules: I) -> HashMap<Vec<String>, Resolved>
+where
+    I: IntoIterator<Item = &'a Module>,
+{
+    let modules: Vec<&'a Module> = modules.into_iter().collect();
+    let mut graph = ModuleGraph::new();
+    let mut collected = Vec::new();
+
+    for module in modules.iter().copied() {
+        let symbols = graph.add_module(module);
+        collected.push((module.name.clone(), symbols));
+    }
+
+    let mut results = HashMap::new();
+    for (module_path, symbols) in collected {
+        let module = modules
+            .iter()
+            .copied()
+            .find(|m| m.name == module_path)
+            .expect("module present in workspace");
+        let ModuleSymbols {
+            module_scope,
+            resolved,
+            ..
+        } = symbols;
+        let mut resolver = Resolver::new(module, module_scope, resolved, &graph);
+        resolver.resolve();
+        results.insert(module_path, resolver.into_resolved());
+    }
+
+    results
 }

--- a/src/semantics/resolve/workspace.rs
+++ b/src/semantics/resolve/workspace.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use crate::syntax::ast::Module;
+
+use super::collector::{ModuleSymbols, collect_module};
+use super::data::{ModuleExports, PathKind, SymbolInfo};
+
+#[derive(Default)]
+pub(super) struct ModuleGraph {
+    exports: HashMap<Vec<String>, ModuleExports>,
+}
+
+impl ModuleGraph {
+    pub(super) fn new() -> Self {
+        Self {
+            exports: HashMap::new(),
+        }
+    }
+
+    pub(super) fn add_module(&mut self, module: &Module) -> ModuleSymbols {
+        let symbols = collect_module(module);
+        self.exports
+            .insert(module.name.clone(), symbols.exports.clone());
+        symbols
+    }
+
+    pub(super) fn lookup(&self, segments: &[String], kind: PathKind) -> Option<SymbolInfo> {
+        if segments.is_empty() {
+            return None;
+        }
+
+        for module_len in (1..segments.len()).rev() {
+            let module_path: Vec<String> = segments[..module_len].to_vec();
+            let Some(exports) = self.exports.get(&module_path) else {
+                continue;
+            };
+            let remainder = &segments[module_len..];
+            if remainder.is_empty() {
+                continue;
+            }
+
+            match kind {
+                PathKind::Type => {
+                    if remainder.len() == 1 {
+                        if let Some(symbol) = exports.types.get(&remainder[0]) {
+                            return Some(symbol.clone());
+                        }
+                    } else if remainder.len() == 2 {
+                        if let Some(symbol) = exports.variants.get(&remainder[1]) {
+                            return Some(symbol.clone());
+                        }
+                    }
+                }
+                PathKind::Value => {
+                    if remainder.len() == 1 {
+                        if let Some(symbol) = exports.values.get(&remainder[0]) {
+                            return Some(symbol.clone());
+                        }
+                        if let Some(symbol) = exports.variants.get(&remainder[0]) {
+                            return Some(symbol.clone());
+                        }
+                    } else if let Some(symbol) = exports.variants.get(remainder.last().unwrap()) {
+                        return Some(symbol.clone());
+                    }
+                }
+                PathKind::Variant => {
+                    if let Some(symbol) = exports.variants.get(remainder.last().unwrap()) {
+                        return Some(symbol.clone());
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}


### PR DESCRIPTION
## Summary
- track per-module exports during collection and share them through a reusable module graph
- allow the resolver to consult the workspace graph so fully-qualified cross-module paths resolve correctly
- add a `resolve_modules` helper and regression test covering multi-module symbol and variant lookups

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d9e260492483308a3c4b2b6b8ffe4d