### PR TITLE
Add diagnostics for unresolved paths in resolver

### DIFF
--- a/src/semantics/resolve/data.rs
+++ b/src/semantics/resolve/data.rs
@@ -9,6 +9,7 @@ pub struct Resolved {
     pub symbols: Vec<SymbolInfo>,
     pub resolved_paths: Vec<ResolvedPath>,
     pub capabilities: Vec<CapabilityBinding>,
+    pub diagnostics: Vec<ResolveDiagnostic>,
 }
 
 #[derive(Debug, Clone)]
@@ -87,6 +88,14 @@ pub enum CapabilityScope {
         module_path: Vec<String>,
         type_name: String,
     },
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolveDiagnostic {
+    pub path: Vec<String>,
+    pub kind: PathKind,
+    pub scope: SymbolScope,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Summary
- record resolver diagnostics when value, type, or variant paths fail to resolve
- expose the diagnostics via the resolver data structures and cover them with regression tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68da0e5151e48330b2d17ed1c43500d7