### PR TITLE
Add SSA-inspired IR module with initial lowering

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,0 +1,419 @@
+use std::collections::HashMap;
+
+use crate::lower::{HBlock, HExpr, HFuncRef, HFunction, HItem, HModule, HStmt};
+use crate::syntax::ast::{BinaryOp, Literal, Path};
+
+#[derive(Debug, Clone)]
+pub struct Module {
+    pub name: Vec<String>,
+    pub functions: Vec<Function>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Function {
+    pub name: String,
+    pub params: Vec<Param>,
+    pub ret_type: Type,
+    pub blocks: Vec<BasicBlock>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Param {
+    pub name: String,
+    pub ty: Type,
+    pub value: ValueId,
+}
+
+#[derive(Debug, Clone)]
+pub struct BasicBlock {
+    pub id: BlockId,
+    pub instructions: Vec<Instruction>,
+    pub terminator: Terminator,
+}
+
+#[derive(Debug, Clone)]
+pub struct Instruction {
+    pub id: ValueId,
+    pub ty: Type,
+    pub kind: InstKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum InstKind {
+    Literal(Literal),
+    Binary {
+        op: BinaryOp,
+        lhs: ValueId,
+        rhs: ValueId,
+    },
+    Call {
+        func: FuncRef,
+        args: Vec<ValueId>,
+    },
+    Record {
+        type_path: Option<Path>,
+        fields: Vec<(String, ValueId)>,
+    },
+    Path(Path),
+}
+
+#[derive(Debug, Clone)]
+pub enum Terminator {
+    Return(Option<ValueId>),
+}
+
+#[derive(Debug, Clone)]
+pub enum FuncRef {
+    Function(Path),
+    Method(String),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ValueId(u32);
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct BlockId(u32);
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Type {
+    Unit,
+    Int,
+    Float,
+    Bool,
+    String,
+    Unknown,
+}
+
+pub fn lower_module(module: &HModule) -> Module {
+    let functions = module
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            HItem::Function(func) => Some(lower_function(func)),
+        })
+        .collect();
+    Module {
+        name: module.name.clone(),
+        functions,
+    }
+}
+
+fn lower_function(func: &HFunction) -> Function {
+    let mut lowerer = FunctionLower::new(func.name.clone());
+    for param in &func.params {
+        lowerer.push_param(param);
+    }
+    lowerer.lower_block(&func.body);
+    lowerer.finish()
+}
+
+struct FunctionLower {
+    name: String,
+    params: Vec<Param>,
+    next_value: u32,
+    current_block: BlockBuilder,
+    blocks: Vec<BasicBlock>,
+    scopes: Vec<HashMap<String, ValueId>>,
+    value_types: HashMap<ValueId, Type>,
+    ret_type: Type,
+}
+
+impl FunctionLower {
+    fn new(name: String) -> Self {
+        let entry = BlockBuilder::new(BlockId(0));
+        FunctionLower {
+            name,
+            params: Vec::new(),
+            next_value: 0,
+            current_block: entry,
+            blocks: Vec::new(),
+            scopes: vec![HashMap::new()],
+            value_types: HashMap::new(),
+            ret_type: Type::Unknown,
+        }
+    }
+
+    fn finish(mut self) -> Function {
+        if self.current_block.terminator.is_none() {
+            let (unit, _) = self.emit_literal(Literal::Unit);
+            self.current_block
+                .set_terminator(Terminator::Return(Some(unit)));
+            self.merge_return_type(Type::Unit);
+        }
+        self.blocks.push(self.current_block.finish());
+        Function {
+            name: self.name,
+            params: self.params,
+            ret_type: self.ret_type,
+            blocks: self.blocks,
+        }
+    }
+
+    fn push_param(&mut self, name: &str) {
+        let id = self.alloc_value();
+        let ty = Type::Unknown;
+        self.scopes
+            .last_mut()
+            .expect("scope stack")
+            .insert(name.to_string(), id);
+        self.value_types.insert(id, ty);
+        self.params.push(Param {
+            name: name.to_string(),
+            ty,
+            value: id,
+        });
+    }
+
+    fn lower_block(&mut self, block: &HBlock) {
+        self.with_scope(|this| {
+            for stmt in &block.stmts {
+                this.lower_stmt(stmt);
+                if this.current_block.terminator.is_some() {
+                    break;
+                }
+            }
+        });
+    }
+
+    fn lower_stmt(&mut self, stmt: &HStmt) {
+        match stmt {
+            HStmt::Let { name, value } => {
+                let (val, ty) = self.lower_expr(value);
+                self.define(name.clone(), val, ty);
+            }
+            HStmt::Expr(expr) => {
+                let _ = self.lower_expr(expr);
+            }
+            HStmt::Return(expr) => {
+                self.lower_return(expr.as_ref());
+            }
+        }
+    }
+
+    fn lower_return(&mut self, expr: Option<&HExpr>) {
+        if self.current_block.terminator.is_some() {
+            return;
+        }
+        let value = expr.map(|e| self.lower_expr(e));
+        let value_id = value.as_ref().map(|(id, _)| *id);
+        if let Some((_, ty)) = &value {
+            self.merge_return_type(*ty);
+        } else {
+            self.merge_return_type(Type::Unit);
+        }
+        self.current_block
+            .set_terminator(Terminator::Return(value_id));
+    }
+
+    fn lower_expr(&mut self, expr: &HExpr) -> (ValueId, Type) {
+        match expr {
+            HExpr::Literal(lit) => self.emit_literal(lit.clone()),
+            HExpr::Var(name) => {
+                let id = self
+                    .lookup(name)
+                    .unwrap_or_else(|| panic!("unknown variable {name}"));
+                let ty = *self.value_types.get(&id).unwrap_or(&Type::Unknown);
+                (id, ty)
+            }
+            HExpr::Path(path) => {
+                if path.segments.len() == 1 {
+                    if let Some(id) = self.lookup(&path.segments[0]) {
+                        let ty = *self.value_types.get(&id).unwrap_or(&Type::Unknown);
+                        return (id, ty);
+                    }
+                }
+                self.emit_instruction(InstKind::Path(path.clone()), Type::Unknown)
+            }
+            HExpr::Call { func, args } => {
+                let mut lowered_args = Vec::with_capacity(args.len());
+                for arg in args {
+                    let (id, _) = self.lower_expr(arg);
+                    lowered_args.push(id);
+                }
+                let func_ref = match func {
+                    HFuncRef::Function(path) => FuncRef::Function(path.clone()),
+                    HFuncRef::Method(name) => FuncRef::Method(name.clone()),
+                };
+                self.emit_instruction(
+                    InstKind::Call {
+                        func: func_ref,
+                        args: lowered_args,
+                    },
+                    Type::Unknown,
+                )
+            }
+            HExpr::Binary { lhs, op, rhs } => {
+                let (lhs_id, lhs_ty) = self.lower_expr(lhs);
+                let (rhs_id, rhs_ty) = self.lower_expr(rhs);
+                let ty = if lhs_ty == rhs_ty && lhs_ty != Type::Unknown {
+                    lhs_ty
+                } else {
+                    Type::Unknown
+                };
+                self.emit_instruction(
+                    InstKind::Binary {
+                        op: *op,
+                        lhs: lhs_id,
+                        rhs: rhs_id,
+                    },
+                    ty,
+                )
+            }
+            HExpr::Block(block) => self.lower_block_expr(block),
+            HExpr::Record { type_path, fields } => {
+                let mut lowered_fields = Vec::with_capacity(fields.len());
+                for (name, value) in fields {
+                    let (id, _) = self.lower_expr(value);
+                    lowered_fields.push((name.clone(), id));
+                }
+                self.emit_instruction(
+                    InstKind::Record {
+                        type_path: type_path.clone(),
+                        fields: lowered_fields,
+                    },
+                    Type::Unknown,
+                )
+            }
+        }
+    }
+
+    fn lower_block_expr(&mut self, block: &HBlock) -> (ValueId, Type) {
+        let mut result: Option<(ValueId, Type)> = None;
+        self.with_scope(|this| {
+            for stmt in &block.stmts {
+                match stmt {
+                    HStmt::Let { name, value } => {
+                        let (val, ty) = this.lower_expr(value);
+                        this.define(name.clone(), val, ty);
+                    }
+                    HStmt::Expr(expr) => {
+                        result = Some(this.lower_expr(expr));
+                    }
+                    HStmt::Return(expr) => {
+                        this.lower_return(expr.as_ref());
+                    }
+                }
+                if this.current_block.terminator.is_some() {
+                    break;
+                }
+            }
+        });
+        if let Some(res) = result {
+            res
+        } else {
+            self.emit_literal(Literal::Unit)
+        }
+    }
+
+    fn emit_literal(&mut self, literal: Literal) -> (ValueId, Type) {
+        let ty = Type::from_literal(&literal);
+        self.emit_instruction(InstKind::Literal(literal), ty)
+    }
+
+    fn emit_instruction(&mut self, kind: InstKind, ty: Type) -> (ValueId, Type) {
+        if self.current_block.terminator.is_some() {
+            panic!("attempted to emit instruction after block was terminated");
+        }
+        let id = self.alloc_value();
+        let instr = Instruction { id, ty, kind };
+        self.value_types.insert(id, ty);
+        self.current_block.push_instruction(instr);
+        (id, ty)
+    }
+
+    fn define(&mut self, name: String, value: ValueId, ty: Type) {
+        self.value_types.entry(value).or_insert(ty);
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.insert(name, value);
+        }
+    }
+
+    fn lookup(&self, name: &str) -> Option<ValueId> {
+        for scope in self.scopes.iter().rev() {
+            if let Some(id) = scope.get(name) {
+                return Some(*id);
+            }
+        }
+        None
+    }
+
+    fn with_scope<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut Self),
+    {
+        self.scopes.push(HashMap::new());
+        f(self);
+        self.scopes.pop();
+    }
+
+    fn merge_return_type(&mut self, ty: Type) {
+        self.ret_type = match (self.ret_type, ty) {
+            (Type::Unknown, other) => other,
+            (existing, other) if existing == other => existing,
+            _ => Type::Unknown,
+        };
+    }
+
+    fn alloc_value(&mut self) -> ValueId {
+        let id = ValueId(self.next_value);
+        self.next_value += 1;
+        id
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BlockBuilder {
+    id: BlockId,
+    instructions: Vec<Instruction>,
+    terminator: Option<Terminator>,
+}
+
+impl BlockBuilder {
+    fn new(id: BlockId) -> Self {
+        BlockBuilder {
+            id,
+            instructions: Vec::new(),
+            terminator: None,
+        }
+    }
+
+    fn push_instruction(&mut self, inst: Instruction) {
+        self.instructions.push(inst);
+    }
+
+    fn set_terminator(&mut self, terminator: Terminator) {
+        self.terminator = Some(terminator);
+    }
+
+    fn finish(self) -> BasicBlock {
+        BasicBlock {
+            id: self.id,
+            instructions: self.instructions,
+            terminator: self.terminator.unwrap_or(Terminator::Return(None)),
+        }
+    }
+}
+
+impl ValueId {
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
+impl Default for ValueId {
+    fn default() -> Self {
+        ValueId(u32::MAX)
+    }
+}
+
+impl Type {
+    fn from_literal(literal: &Literal) -> Type {
+        match literal {
+            Literal::Unit => Type::Unit,
+            Literal::Int(_) => Type::Int,
+            Literal::Float(_) => Type::Float,
+            Literal::Bool(_) => Type::Bool,
+            Literal::String(_) => Type::String,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod diagnostics;
+pub mod ir;
 pub mod lower;
 pub mod pretty;
 pub mod semantics;

--- a/src/tests/ir_tests.rs
+++ b/src/tests/ir_tests.rs
@@ -1,0 +1,75 @@
+use super::helpers::*;
+use super::*;
+
+#[test]
+fn lower_simple_function_into_ir() {
+    let src = r#"
+module demo
+
+fn add(x: Int, y: Int) -> Int {
+  let sum = x + y
+  return sum
+}
+"#;
+
+    let module = parse(src);
+    let hir = lower::lower_module(&module);
+    let ir_module = ir::lower_module(&hir);
+
+    assert_eq!(ir_module.name, vec!["demo".to_string()]);
+    assert_eq!(ir_module.functions.len(), 1);
+
+    let func = &ir_module.functions[0];
+    assert_eq!(func.name, "add");
+    assert_eq!(func.params.len(), 2);
+    assert_eq!(func.blocks.len(), 1);
+
+    let block = &func.blocks[0];
+    assert_eq!(block.instructions.len(), 1);
+    match &block.instructions[0].kind {
+        ir::InstKind::Binary { op, .. } => assert_eq!(*op, BinaryOp::Add),
+        other => panic!("expected binary instruction, got {other:?}"),
+    }
+    match &block.terminator {
+        ir::Terminator::Return(Some(ret)) => {
+            assert_eq!(*ret, block.instructions[0].id);
+        }
+        other => panic!("expected return terminator, got {other:?}"),
+    }
+}
+
+#[test]
+fn lowering_literal_return_tracks_type_information() {
+    let src = r#"
+module demo
+
+fn forty_two() -> Int {
+  return 42
+}
+"#;
+
+    let module = parse(src);
+    let hir = lower::lower_module(&module);
+    let ir_module = ir::lower_module(&hir);
+
+    let func = ir_module
+        .functions
+        .iter()
+        .find(|f| f.name == "forty_two")
+        .expect("function");
+    assert_eq!(func.ret_type, ir::Type::Int);
+
+    let block = &func.blocks[0];
+    assert_eq!(block.instructions.len(), 1);
+    assert_eq!(block.instructions[0].ty, ir::Type::Int);
+    match &block.instructions[0].kind {
+        ir::InstKind::Literal(Literal::Int(value)) => assert_eq!(*value, 42),
+        other => panic!("expected int literal, got {other:?}"),
+    }
+    match &block.terminator {
+        ir::Terminator::Return(Some(ret)) => {
+            assert_eq!(*ret, block.instructions[0].id);
+        }
+        other => panic!("expected return terminator, got {other:?}"),
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,10 +3,11 @@
 use crate::diagnostics::error::{Error, ErrorKind};
 use crate::semantics::{check, resolve};
 use crate::syntax::{ast::*, lexer, parser, token::TokenKind};
-use crate::{lower, pretty};
+use crate::{ir, lower, pretty};
 
 mod display_tests;
 mod helpers;
+mod ir_tests;
 mod lexer_tests;
 mod lowering_tests;
 mod parser_tests;


### PR DESCRIPTION
## Summary
- add a first-pass SSA-inspired intermediate representation with blocks, instructions, and value tracking
- lower existing HIR functions into the new IR while tracking local scopes and basic types
- cover the new lowering flow with initial IR-specific tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68daeac3ceb0833095f2e43197ece893