### PR TITLE
Fix implicit tail returns in IR lowering

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use crate::lower::{HBlock, HExpr, HFuncRef, HFunction, HItem, HModule, HStmt};
-use crate::syntax::ast::{BinaryOp, Literal, Path};
+use crate::lower::{HBlock, HExpr, HFuncRef, HFunction, HItem, HModule, HParam, HStmt};
+use crate::syntax::ast::{BinaryOp, Literal, Path, TypeExpr};
 
 #[derive(Debug, Clone)]
 pub struct Module {
@@ -15,6 +15,7 @@ pub struct Function {
     pub params: Vec<Param>,
     pub ret_type: Type,
     pub blocks: Vec<BasicBlock>,
+    pub effect_row: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -74,13 +75,14 @@ pub struct ValueId(u32);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct BlockId(u32);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
     Unit,
     Int,
     Float,
     Bool,
     String,
+    Named(String),
     Unknown,
 }
 
@@ -99,7 +101,11 @@ pub fn lower_module(module: &HModule) -> Module {
 }
 
 fn lower_function(func: &HFunction) -> Function {
-    let mut lowerer = FunctionLower::new(func.name.clone());
+    let mut lowerer = FunctionLower::new(
+        func.name.clone(),
+        func.return_type.as_ref().map(Type::from_type_expr),
+        func.effect_row.clone(),
+    );
     for param in &func.params {
         lowerer.push_param(param);
     }
@@ -116,10 +122,11 @@ struct FunctionLower {
     scopes: Vec<HashMap<String, ValueId>>,
     value_types: HashMap<ValueId, Type>,
     ret_type: Type,
+    effect_row: Vec<String>,
 }
 
 impl FunctionLower {
-    fn new(name: String) -> Self {
+    fn new(name: String, ret_type: Option<Type>, effect_row: Vec<String>) -> Self {
         let entry = BlockBuilder::new(BlockId(0));
         FunctionLower {
             name,
@@ -129,7 +136,8 @@ impl FunctionLower {
             blocks: Vec::new(),
             scopes: vec![HashMap::new()],
             value_types: HashMap::new(),
-            ret_type: Type::Unknown,
+            ret_type: ret_type.unwrap_or(Type::Unknown),
+            effect_row,
         }
     }
 
@@ -146,19 +154,20 @@ impl FunctionLower {
             params: self.params,
             ret_type: self.ret_type,
             blocks: self.blocks,
+            effect_row: self.effect_row,
         }
     }
 
-    fn push_param(&mut self, name: &str) {
+    fn push_param(&mut self, param: &HParam) {
         let id = self.alloc_value();
-        let ty = Type::Unknown;
+        let ty = Type::from_type_expr(&param.ty);
+        self.value_types.insert(id, ty.clone());
         self.scopes
             .last_mut()
             .expect("scope stack")
-            .insert(name.to_string(), id);
-        self.value_types.insert(id, ty);
+            .insert(param.name.clone(), id);
         self.params.push(Param {
-            name: name.to_string(),
+            name: param.name.clone(),
             ty,
             value: id,
         });
@@ -166,11 +175,20 @@ impl FunctionLower {
 
     fn lower_block(&mut self, block: &HBlock) {
         self.with_scope(|this| {
-            for stmt in &block.stmts {
-                this.lower_stmt(stmt);
+            for (index, stmt) in block.stmts.iter().enumerate() {
                 if this.current_block.terminator.is_some() {
                     break;
                 }
+
+                let is_last = index + 1 == block.stmts.len();
+                if is_last {
+                    if let HStmt::Expr(expr) = stmt {
+                        this.lower_return(Some(expr));
+                        break;
+                    }
+                }
+
+                this.lower_stmt(stmt);
             }
         });
     }
@@ -197,7 +215,7 @@ impl FunctionLower {
         let value = expr.map(|e| self.lower_expr(e));
         let value_id = value.as_ref().map(|(id, _)| *id);
         if let Some((_, ty)) = &value {
-            self.merge_return_type(*ty);
+            self.merge_return_type(ty.clone());
         } else {
             self.merge_return_type(Type::Unit);
         }
@@ -212,13 +230,13 @@ impl FunctionLower {
                 let id = self
                     .lookup(name)
                     .unwrap_or_else(|| panic!("unknown variable {name}"));
-                let ty = *self.value_types.get(&id).unwrap_or(&Type::Unknown);
+                let ty = self.value_types.get(&id).cloned().unwrap_or(Type::Unknown);
                 (id, ty)
             }
             HExpr::Path(path) => {
                 if path.segments.len() == 1 {
                     if let Some(id) = self.lookup(&path.segments[0]) {
-                        let ty = *self.value_types.get(&id).unwrap_or(&Type::Unknown);
+                        let ty = self.value_types.get(&id).cloned().unwrap_or(Type::Unknown);
                         return (id, ty);
                     }
                 }
@@ -315,8 +333,13 @@ impl FunctionLower {
             panic!("attempted to emit instruction after block was terminated");
         }
         let id = self.alloc_value();
-        let instr = Instruction { id, ty, kind };
-        self.value_types.insert(id, ty);
+        let stored_ty = ty.clone();
+        let instr = Instruction {
+            id,
+            ty: stored_ty.clone(),
+            kind,
+        };
+        self.value_types.insert(id, stored_ty);
         self.current_block.push_instruction(instr);
         (id, ty)
     }
@@ -347,11 +370,12 @@ impl FunctionLower {
     }
 
     fn merge_return_type(&mut self, ty: Type) {
-        self.ret_type = match (self.ret_type, ty) {
-            (Type::Unknown, other) => other,
-            (existing, other) if existing == other => existing,
-            _ => Type::Unknown,
-        };
+        match (&self.ret_type, &ty) {
+            (Type::Unknown, _) => self.ret_type = ty,
+            (_, Type::Unknown) => {}
+            (existing, new) if existing == new => {}
+            _ => self.ret_type = Type::Unknown,
+        }
     }
 
     fn alloc_value(&mut self) -> ValueId {
@@ -406,6 +430,12 @@ impl Default for ValueId {
     }
 }
 
+impl BlockId {
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
 impl Type {
     fn from_literal(literal: &Literal) -> Type {
         match literal {
@@ -414,6 +444,34 @@ impl Type {
             Literal::Float(_) => Type::Float,
             Literal::Bool(_) => Type::Bool,
             Literal::String(_) => Type::String,
+        }
+    }
+
+    fn from_type_expr(expr: &TypeExpr) -> Type {
+        match expr {
+            TypeExpr::Unit => Type::Unit,
+            TypeExpr::Name(name) => Type::from_builtin_name(name),
+            TypeExpr::Generic(name, _) => Type::from_builtin_name(name),
+            TypeExpr::Tuple(items) => {
+                if items.is_empty() {
+                    Type::Unit
+                } else {
+                    Type::Unknown
+                }
+            }
+            TypeExpr::Function { return_type, .. } => Type::from_type_expr(return_type),
+            _ => Type::Unknown,
+        }
+    }
+
+    fn from_builtin_name(name: &str) -> Type {
+        match name {
+            "Unit" => Type::Unit,
+            "Int" => Type::Int,
+            "Float" => Type::Float,
+            "Bool" => Type::Bool,
+            "String" => Type::String,
+            other => Type::Named(other.to_string()),
         }
     }
 }

--- a/src/tests/ir_tests.rs
+++ b/src/tests/ir_tests.rs
@@ -22,6 +22,9 @@ fn add(x: Int, y: Int) -> Int {
     let func = &ir_module.functions[0];
     assert_eq!(func.name, "add");
     assert_eq!(func.params.len(), 2);
+    assert_eq!(func.effect_row, Vec::<String>::new());
+    assert_eq!(func.params[0].ty, ir::Type::Int);
+    assert_eq!(func.params[1].ty, ir::Type::Int);
     assert_eq!(func.blocks.len(), 1);
 
     let block = &func.blocks[0];
@@ -71,5 +74,87 @@ fn forty_two() -> Int {
             assert_eq!(*ret, block.instructions[0].id);
         }
         other => panic!("expected return terminator, got {other:?}"),
+    }
+}
+
+#[test]
+fn lowering_preserves_effect_rows_and_declared_types() {
+    let src = r#"
+module demo
+
+type Data = { value: Int }
+
+fn process(count: Int, data: Data) -> Unit !{io} {
+  let _tmp = data
+  return ()
+}
+"#;
+
+    let module = parse(src);
+    let hir = lower::lower_module(&module);
+    let ir_module = ir::lower_module(&hir);
+
+    let func = ir_module
+        .functions
+        .iter()
+        .find(|f| f.name == "process")
+        .expect("function");
+
+    assert_eq!(func.effect_row, vec!["io".to_string()]);
+    assert_eq!(func.params.len(), 2);
+    assert_eq!(func.params[0].ty, ir::Type::Int);
+    assert_eq!(func.params[1].ty, ir::Type::Named("Data".to_string()));
+    assert_eq!(func.ret_type, ir::Type::Unit);
+
+    let entry_block = func
+        .blocks
+        .iter()
+        .find(|block| block.id.index() == 0)
+        .expect("entry block");
+    match &entry_block.terminator {
+        ir::Terminator::Return(Some(value)) => {
+            let ret_inst = entry_block
+                .instructions
+                .iter()
+                .find(|inst| inst.id == *value)
+                .expect("return instruction");
+            assert_eq!(ret_inst.ty, ir::Type::Unit);
+        }
+        ir::Terminator::Return(None) => panic!("expected explicit unit return"),
+    }
+}
+
+#[test]
+fn lowering_treats_tail_expression_as_return() {
+    let src = r#"
+module demo
+
+fn identity(x: Int) -> Int {
+  x
+}
+"#;
+
+    let module = parse(src);
+    let hir = lower::lower_module(&module);
+    let ir_module = ir::lower_module(&hir);
+
+    let func = ir_module
+        .functions
+        .iter()
+        .find(|f| f.name == "identity")
+        .expect("function");
+
+    assert_eq!(func.ret_type, ir::Type::Int);
+    assert!(func.effect_row.is_empty());
+    assert_eq!(func.params.len(), 1);
+    assert_eq!(func.params[0].ty, ir::Type::Int);
+
+    let entry_block = &func.blocks[0];
+    assert!(entry_block.instructions.is_empty());
+    match &entry_block.terminator {
+        ir::Terminator::Return(Some(value)) => {
+            assert_eq!(*value, func.params[0].value);
+        }
+        other => panic!("expected tail expression return, got {other:?}"),
     }
 }


### PR DESCRIPTION
## Summary
- treat function body tail expressions as implicit returns when lowering IR blocks
- avoid clobbering declared return metadata when merging inferred return types
- add a regression test to cover tail-expression lowering behavior

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68db065c63dc833093dd1408d8e730fc