### PR TITLE
Add LLVM backend scaffold and document IR contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ cargo build
 cargo test
 ```
 
-Running `cargo run` with the path to a `.mica` file executes the CLI in its
-default `--ast` mode:
+Running `cargo run --bin mica` with the path to a `.mica` file executes the CLI
+in its default `--ast` mode:
 
 ```bash
-cargo run -- examples/demo.mica
+cargo run --bin mica -- examples/demo.mica
 ```
 
 ## Command-line interface
@@ -66,13 +66,14 @@ The CLI surfaces multiple compiler stages behind feature flags. Combine them as
 needed:
 
 ```bash
-cargo run -- --tokens examples/demo.mica      # Lex the source file
-cargo run -- --ast examples/demo.mica         # Parse into an AST (default mode)
-cargo run -- --ast --pretty examples/adt.mica # Pretty-print the AST
-cargo run -- --resolve examples/adt.mica      # Inspect bindings and capabilities
-cargo run -- --check examples/adt.mica        # Exhaustiveness checks
-cargo run -- --lower examples/methods.mica    # Lower to the simple HIR
-cargo run -- --ir examples/methods.mica       # Dump the typed SSA IR via the backend shim
+cargo run --bin mica -- --tokens examples/demo.mica      # Lex the source file
+cargo run --bin mica -- --ast examples/demo.mica         # Parse into an AST (default mode)
+cargo run --bin mica -- --ast --pretty examples/adt.mica # Pretty-print the AST
+cargo run --bin mica -- --resolve examples/adt.mica      # Inspect bindings and capabilities
+cargo run --bin mica -- --check examples/adt.mica        # Exhaustiveness checks
+cargo run --bin mica -- --lower examples/methods.mica    # Lower to the simple HIR
+cargo run --bin mica -- --ir examples/methods.mica       # Dump the typed SSA IR via the backend shim
+cargo run --bin mica -- --llvm examples/methods.mica     # Emit the LLVM scaffolding preview
 ```
 
 CLI output snapshots are maintained in [`docs/snippets.md`](docs/snippets.md).

--- a/docs/modules/cli.md
+++ b/docs/modules/cli.md
@@ -11,9 +11,9 @@ written guides synchronized with reality.
 
 | Area | Description |
 | --- | --- |
-| Argument parsing | `run()` parses flags such as `--tokens`, `--ast`, `--pretty`, `--check`, `--resolve`, `--lower`, and the new `--ir` backend dump, validating that exactly one input path is supplied.【F:src/main.rs†L25-L57】 |
-| Mode dispatch | The `Mode` enum enumerates each compiler stage that can be surfaced through the CLI and makes it trivial to wire additional passes as roadmap milestones land.【F:src/main.rs†L205-L213】 |
-| Pipeline execution | Each mode reuses the same parse step and then calls into the relevant library module to print tokens, ASTs, semantic diagnostics, resolver output, lowered HIR strings, or typed IR dumps.【F:src/main.rs†L58-L200】 |
+| Argument parsing | `run()` parses flags such as `--tokens`, `--ast`, `--pretty`, `--check`, `--resolve`, `--lower`, the textual `--ir` dump, and the LLVM preview `--llvm`, validating that exactly one input path is supplied.【F:src/main.rs†L17-L63】 |
+| Mode dispatch | The `Mode` enum enumerates each compiler stage that can be surfaced through the CLI and makes it trivial to wire additional passes as roadmap milestones land.【F:src/main.rs†L207-L215】 |
+| Pipeline execution | Each mode reuses the same parse step and then calls into the relevant library module to print tokens, ASTs, semantic diagnostics, resolver output, lowered HIR strings, or backend dumps.【F:src/main.rs†L63-L204】 |
 | Error reporting | CLI errors are normalized through the shared diagnostics helpers so messages remain consistent across modules.【F:src/main.rs†L35-L47】 |
 | Documentation snapshots | `gen_snippets` rebuilds the project, executes curated commands over `examples/`, and updates `docs/snippets.md` or verifies it in `--check` mode for CI.【F:src/bin/gen_snippets.rs†L1-L60】 |
 
@@ -21,7 +21,7 @@ written guides synchronized with reality.
 
 - `Mode`: Centralized enumeration of exposed stages; follow the established
   pattern when adding backend or optimization passes from Phase 3 of the
-  compiler roadmap.【F:src/main.rs†L205-L213】【F:docs/roadmap/compiler.md†L126-L215】
+  compiler roadmap.【F:src/main.rs†L207-L215】【F:docs/roadmap/compiler.md†L126-L215】
 - `resolve::ResolvedModule`: Data printed by `--resolve`, including module path,
   imports, symbol metadata, capabilities, and resolved paths. It is an important
   integration surface for forthcoming IDE tooling.【F:src/main.rs†L75-L175】【F:docs/roadmap/tooling.md†L1-L60】
@@ -46,8 +46,7 @@ written guides synchronized with reality.
 - **Phase 1 (Static analysis):** The `--check` and `--resolve` modes already pipe
   through type/effect checks and resolver output, providing scaffolding for more
   advanced diagnostics and borrow checking planned in this phase.【F:docs/roadmap/compiler.md†L76-L125】
-- **Phase 2 (Lowering groundwork):** `--lower` and `--ir` expose both the HIR and
-  the typed SSA IR, easing debugging as backend integrations mature.【F:src/main.rs†L186-L200】【F:docs/roadmap/compiler.md†L126-L170】
+- **Phase 2 (Lowering groundwork):** `--lower`, `--ir`, and `--llvm` expose both the HIR and the backend contracts, easing debugging as backend integrations mature.【F:src/main.rs†L184-L201】【F:docs/roadmap/compiler.md†L126-L170】
 - **Phase 3 (Backend and ecosystem tooling):** The structured `Mode` enum and
   snapshot tooling leave room to add code generation, optimization, and package
   manager commands outlined for later phases.【F:docs/roadmap/compiler.md†L170-L215】【F:docs/roadmap/ecosystem.md†L1-L78】

--- a/docs/modules/diagnostics.md
+++ b/docs/modules/diagnostics.md
@@ -57,3 +57,6 @@ roadmap.
 3. **Track roadmap alignment.** Each milestone documents diagnostic exit
    criteria so we know when Phase 2’s richer IR and backend hooks are ready to
    surface structured errors downstream.【F:docs/roadmap/milestones.md†L1-L120】
+4. **Snapshot backend surfacing.** The backend regression suite now asserts
+   that both textual and LLVM scaffolding outputs retain capability metadata,
+   giving diagnostics parity between CLI previews and future native builds.【F:src/tests/backend_tests.rs†L1-L96】

--- a/docs/modules/ir.md
+++ b/docs/modules/ir.md
@@ -3,17 +3,18 @@
 ## Scope
 
 The SSA-oriented IR defined in `src/ir/mod.rs` lowers the high-level HIR into
-basic blocks, instructions, and typed values. It forms the backbone of Phase 2
-and Phase 3 roadmap milestones focused on optimization and code generation.
+basic blocks, instructions, typed values, and capability-aware metadata. The
+design now doubles as living documentation for the backend contract thanks to
+the LLVM scaffolding backend added in this milestone.
 
 ## Core Types
 
 | Type | Purpose |
 | --- | --- |
-| `Module` | Owns lowered functions alongside shared type/effect tables so backends see a self-contained package of IR plus metadata.【F:src/ir/mod.rs†L8-L169】 |
-| `Function` | Holds parameters, `TypeId` return metadata, basic blocks, and effect identifiers describing capability requirements.【F:src/ir/mod.rs†L17-L225】 |
+| `Module` | Owns lowered functions alongside shared type/effect tables and exposes helpers such as `unknown_type` so backends can recover canonical metadata without re-interning anything.【F:src/ir/mod.rs†L8-L174】 |
+| `Function` | Holds parameters, `TypeId` return metadata, basic blocks, and effect identifiers describing capability requirements for each body.【F:src/ir/mod.rs†L17-L225】 |
 | `BasicBlock` | Represents a control-flow node with instructions and a terminator (currently return).【F:src/ir/mod.rs†L32-L68】 |
-| `Instruction` | Encodes SSA values with IDs, referenced types, and instruction kinds such as literals, binary ops, calls, and records.【F:src/ir/mod.rs†L39-L63】【F:src/ir/mod.rs†L407-L416】 |
+| `Instruction` | Encodes SSA values with IDs, referenced types, and instruction kinds such as literals, binary ops, calls, records, and resolved paths.【F:src/ir/mod.rs†L39-L63】【F:src/ir/mod.rs†L407-L416】 |
 | `TypeTable` & `TypeId` | Intern and reuse structural types so large modules share canonical IDs while keeping lookups O(1).【F:src/ir/mod.rs†L100-L170】【F:src/ir/mod.rs†L538-L584】 |
 | `EffectTable` & `EffectId` | Deduplicate effect names, allowing effect rows to scale linearly with references instead of strings.【F:src/ir/mod.rs†L106-L170】【F:src/ir/mod.rs†L586-L600】 |
 
@@ -32,10 +33,10 @@ and Phase 3 roadmap milestones focused on optimization and code generation.
 
 1. Consumes the HIR structures from the lowering stage, ensuring desugared
    constructs map cleanly onto SSA building blocks.【F:src/ir/mod.rs†L3-L399】【F:src/lower/mod.rs†L3-L320】
-2. Ships canonical type and effect registries that backend integrations (text,
-   LLVM, WASM) can query without re-resolving AST nodes.【F:src/ir/mod.rs†L498-L600】【F:src/backend/text.rs†L1-L129】
+2. Ships canonical type and effect registries that backend integrations (text
+   dumps today, LLVM tomorrow) can query without re-resolving AST nodes.【F:src/ir/mod.rs†L498-L600】【F:src/backend/text.rs†L1-L129】【F:src/backend/llvm.rs†L1-L226】
 3. Tests under `src/tests` exercise IR typing, effect rows, and backend output,
-   preventing regressions as the IR evolves.【F:src/tests/ir_tests.rs†L1-L132】【F:src/tests/backend_tests.rs†L1-L55】
+   preventing regressions as the IR evolves.【F:src/tests/ir_tests.rs†L1-L132】【F:src/tests/backend_tests.rs†L1-L96】
 
 ## Roadmap Alignment
 

--- a/docs/roadmap/next-step.md
+++ b/docs/roadmap/next-step.md
@@ -23,3 +23,8 @@ With Phase 1 complete, the focus shifts to the next tranche of roadmap tasks:
 Clearing these items transitions the project into Phase 2, setting the stage for
 SSA lowering, backend work, and the optimizer research called out in the
 compiler roadmap.
+
+_Status update:_ The typed IR specification now lives in `docs/modules/ir.md`,
+an LLVM scaffolding backend exports the contract through `mica --llvm`, and the
+diagnostics playbook plus CLI examples document the richer pipeline surface so
+contributors can iterate confidently.【F:docs/modules/ir.md†L1-L70】【F:src/backend/llvm.rs†L1-L226】【F:docs/snippets.md†L1-L80】

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -4,7 +4,7 @@ This page shows short outputs from the CLI for selected examples.
 
 ## Pretty AST (`--ast --pretty`)
 
-Command: `cargo run -- --ast --pretty examples/adt.mica`
+Command: `cargo run --bin mica -- --ast --pretty examples/adt.mica`
 
 ```
 module demo.adt
@@ -15,7 +15,7 @@ pub fn map_option[T, U](x: Option[T], f: fn(T) -> U) -> Option[U] { … }
 
 ## Exhaustiveness Check (`--check`)
 
-Command: `cargo run -- --check examples/adt_match_nonexhaustive.mica`
+Command: `cargo run --bin mica -- --check examples/adt_match_nonexhaustive.mica`
 
 ```
 warning: non-exhaustive match for Color: missing variants Green, Blue
@@ -23,7 +23,7 @@ warning: non-exhaustive match for Color: missing variants Green, Blue
 
 ## Lowered HIR (`--lower`)
 
-Command: `cargo run -- --lower examples/methods.mica`
+Command: `cargo run --bin mica -- --lower examples/methods.mica`
 
 ```
 hir module demo.methods
@@ -31,7 +31,34 @@ fn use_method(a, b)
   add(a, b)
 ```
 
-Command: `cargo run -- --lower examples/spawn_await.mica`
+## Typed IR (`--ir`)
+
+Command: `cargo run --bin mica -- --ir examples/methods.mica`
+
+```
+module demo.methods
+
+fn use_method(a: Vec2, b: Vec2) -> Vec2
+  block 0:
+    %2 = call add(%0, %1) : _
+    return %2
+```
+
+## LLVM Scaffold (`--llvm`)
+
+Command: `cargo run --bin mica -- --llvm examples/methods.mica`
+
+```
+; ModuleID = 'demo.methods'
+
+define %Vec2 @use_method(%Vec2 %a, %Vec2 %b) {
+bb0:
+  ; %2 : ptr = call %add(%0, %1)
+  ret ptr %2
+}
+```
+
+Command: `cargo run --bin mica -- --lower examples/spawn_await.mica`
 
 ```
 hir module demo.concurrent

--- a/docs/status.md
+++ b/docs/status.md
@@ -4,9 +4,9 @@ _Last updated: 2025-09-29 23:23 UTC_
 
 ## Current Health Check
 - **Compiler pipeline**: Lexer, parser, resolver, and type checker are implemented and covered by regression tests.
-- **Typed IR**: Lowerer assigns stable `TypeId`s with shared registries; CLI exposes `mica --ir` for inspection.
-- **Backend**: Text emitter backend renders typed IR for validation and future backend adapters.
-- **Diagnostics**: Playbook refreshed with Phase 2 criteria; CLI documentation mirrors current surface area.
+- **Typed IR**: Lowerer assigns stable `TypeId`s with shared registries; design notes now describe backend expectations and helpers like `Module::unknown_type` for consumers.【F:docs/modules/ir.md†L1-L70】
+- **Backend**: Text emitter plus the new LLVM scaffolding backend render typed IR with effect metadata for validation and future native code generation.【F:src/backend/llvm.rs†L1-L226】【F:src/tests/backend_tests.rs†L1-L96】
+- **Diagnostics**: Playbook refreshed with backend snapshots and CLI documentation mirrors the expanded surface area, including new IR examples.【F:docs/modules/diagnostics.md†L1-L89】【F:docs/snippets.md†L1-L80】
 
 ## Test & Verification Snapshot
 - `cargo test` (unit + integration) — all 36 suites pass locally.
@@ -14,8 +14,8 @@ _Last updated: 2025-09-29 23:23 UTC_
 
 ## Near-Term Priorities
 1. Flesh out typed IR coverage for control-flow joins, pattern destructuring, and effect polymorphism.
-2. Design backend trait abstractions that can target LLVM and WASM while reusing registries.
-3. Extend diagnostics regression matrix with IR-specific failure fixtures.
+2. Harden the LLVM scaffolding into a codegen pipeline that lowers SSA blocks into real LLVM IR instructions.
+3. Extend diagnostics regression matrix with IR-specific failure fixtures and backend error cases.
 4. Explore purity analysis for structured concurrency primitives ahead of runtime work.
 
 ## Risks & Watch Items

--- a/src/backend/llvm.rs
+++ b/src/backend/llvm.rs
@@ -1,0 +1,226 @@
+use std::collections::HashMap;
+use std::fmt::Write;
+
+use crate::ir::{self, InstKind, Terminator, Type, TypeId, ValueId};
+
+use super::{Backend, BackendOptions, BackendResult};
+
+/// Scaffolding backend that translates the typed SSA module into a
+/// lightweight LLVM-flavoured IR string. The intent is to expose a stable
+/// contract for future native code generation work without pulling in LLVM
+/// as a dependency yet.
+#[derive(Debug, Default, Clone)]
+pub struct LlvmBackend {
+    /// Preferred target triple for the emitted module. When `None`, the
+    /// backend falls back to `BackendOptions::target_triple` or leaves the
+    /// triple unspecified so later stages can decide.
+    pub target_triple: Option<String>,
+}
+
+/// Result of the LLVM backend scaffolding. The IR is stored verbatim so
+/// downstream tooling can persist it to disk or feed it into the real LLVM
+/// toolchain when it lands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LlvmModule {
+    pub ir: String,
+    pub target_triple: Option<String>,
+}
+
+impl LlvmModule {
+    pub fn as_str(&self) -> &str {
+        &self.ir
+    }
+}
+
+impl Backend for LlvmBackend {
+    type Output = LlvmModule;
+
+    fn compile(
+        &self,
+        module: &ir::Module,
+        options: &BackendOptions,
+    ) -> BackendResult<Self::Output> {
+        let triple = self
+            .target_triple
+            .clone()
+            .or_else(|| options.target_triple.clone());
+        let mut renderer = ModuleRenderer::new(module, triple.clone());
+        let ir = renderer.render();
+        Ok(LlvmModule {
+            ir,
+            target_triple: triple,
+        })
+    }
+}
+
+struct ModuleRenderer<'m> {
+    module: &'m ir::Module,
+    target_triple: Option<String>,
+}
+
+impl<'m> ModuleRenderer<'m> {
+    fn new(module: &'m ir::Module, target_triple: Option<String>) -> Self {
+        ModuleRenderer {
+            module,
+            target_triple,
+        }
+    }
+
+    fn render(&mut self) -> String {
+        let mut out = String::new();
+        let module_name = self.module.name.join(".");
+        writeln!(out, "; ModuleID = '{}'", module_name).unwrap();
+        if let Some(triple) = &self.target_triple {
+            writeln!(out, "target triple = \"{}\"", triple).unwrap();
+        }
+        writeln!(out).unwrap();
+
+        for function in &self.module.functions {
+            render_function(&mut out, self.module, function);
+            writeln!(out).unwrap();
+        }
+
+        out
+    }
+}
+
+fn render_function(out: &mut String, module: &ir::Module, function: &ir::Function) {
+    let ret_ty = format_type(module, function.ret_type);
+    let mut params = Vec::with_capacity(function.params.len());
+    let mut value_types: HashMap<ValueId, TypeId> = HashMap::new();
+
+    for param in &function.params {
+        value_types.insert(param.value, param.ty);
+        params.push(format!("{} %{}", format_type(module, param.ty), param.name));
+    }
+
+    writeln!(
+        out,
+        "define {} @{}({}) {{",
+        ret_ty,
+        function.name,
+        params.join(", ")
+    )
+    .unwrap();
+
+    if !function.effect_row.is_empty() {
+        let names: Vec<_> = function
+            .effect_row
+            .iter()
+            .map(|effect| module.effect_name(*effect).to_string())
+            .collect();
+        writeln!(out, "  ; effects: {}", names.join(", ")).unwrap();
+    }
+
+    for block in &function.blocks {
+        render_block(out, module, block, &mut value_types);
+    }
+
+    writeln!(out, "}}").unwrap();
+}
+
+fn render_block(
+    out: &mut String,
+    module: &ir::Module,
+    block: &ir::BasicBlock,
+    value_types: &mut HashMap<ValueId, TypeId>,
+) {
+    writeln!(out, "bb{}:", block.id.index()).unwrap();
+    for inst in &block.instructions {
+        value_types.insert(inst.id, inst.ty);
+        let ty = format_type(module, inst.ty);
+        writeln!(
+            out,
+            "  ; %{} : {} = {}",
+            inst.id.index(),
+            ty,
+            format_inst(inst)
+        )
+        .unwrap();
+    }
+    render_terminator(out, module, &block.terminator, value_types);
+}
+
+fn render_terminator(
+    out: &mut String,
+    module: &ir::Module,
+    terminator: &Terminator,
+    value_types: &HashMap<ValueId, TypeId>,
+) {
+    match terminator {
+        Terminator::Return(Some(value)) => {
+            let ty = value_types
+                .get(value)
+                .copied()
+                .unwrap_or_else(|| module.unknown_type());
+            writeln!(out, "  ret {} %{}", format_type(module, ty), value.index()).unwrap();
+        }
+        Terminator::Return(None) => {
+            writeln!(out, "  ret void").unwrap();
+        }
+    }
+}
+
+fn format_inst(inst: &ir::Instruction) -> String {
+    match &inst.kind {
+        InstKind::Literal(literal) => format!("literal {}", format_literal(literal)),
+        InstKind::Binary { op, lhs, rhs } => format!("{} %{}, %{}", op, lhs.index(), rhs.index()),
+        InstKind::Call { func, args } => {
+            let mut rendered_args = Vec::with_capacity(args.len());
+            for arg in args {
+                rendered_args.push(format!("%{}", arg.index()));
+            }
+            match func {
+                ir::FuncRef::Function(path) => format!(
+                    "call @{}({})",
+                    path.segments.join("::"),
+                    rendered_args.join(", ")
+                ),
+                ir::FuncRef::Method(name) => {
+                    format!("call %{}({})", name, rendered_args.join(", "))
+                }
+            }
+        }
+        InstKind::Record { type_path, fields } => {
+            let mut formatted = Vec::new();
+            for (name, value) in fields {
+                formatted.push(format!("{}: %{}", name, value.index()));
+            }
+            match type_path {
+                Some(path) => format!(
+                    "record {} {{{}}}",
+                    path.segments.join("::"),
+                    formatted.join(", ")
+                ),
+                None => format!("record {{{}}}", formatted.join(", ")),
+            }
+        }
+        InstKind::Path(path) => format!("path {}", path.segments.join("::")),
+    }
+}
+
+fn format_literal(literal: &crate::syntax::ast::Literal) -> String {
+    match literal {
+        crate::syntax::ast::Literal::Int(value) => value.to_string(),
+        crate::syntax::ast::Literal::Float(value) => value.to_string(),
+        crate::syntax::ast::Literal::Bool(value) => value.to_string(),
+        crate::syntax::ast::Literal::String(value) => format!("\"{}\"", value),
+        crate::syntax::ast::Literal::Unit => "()".to_string(),
+    }
+}
+
+fn format_type(module: &ir::Module, ty: TypeId) -> String {
+    match module.type_of(ty) {
+        Type::Unit => "void".to_string(),
+        Type::Int => "i64".to_string(),
+        Type::Float => "double".to_string(),
+        Type::Bool => "i1".to_string(),
+        Type::String => "ptr".to_string(),
+        Type::Named(name) => format!("%{}", sanitize_symbol(name)),
+        Type::Unknown => "ptr".to_string(),
+    }
+}
+
+fn sanitize_symbol(name: &str) -> String {
+    name.replace(['.', ':'], "_")
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,12 +2,14 @@ use std::fmt;
 
 use crate::ir;
 
+pub mod llvm;
 pub mod text;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct BackendOptions {
     pub optimize: bool,
     pub debug_info: bool,
+    pub target_triple: Option<String>,
 }
 
 impl Default for BackendOptions {
@@ -15,6 +17,7 @@ impl Default for BackendOptions {
         BackendOptions {
             optimize: false,
             debug_info: false,
+            target_triple: None,
         }
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -489,6 +489,10 @@ impl Module {
     pub fn type_of(&self, id: TypeId) -> &Type {
         self.types.get(id)
     }
+
+    pub fn unknown_type(&self) -> TypeId {
+        self.types.unknown()
+    }
 }
 
 impl ValueId {


### PR DESCRIPTION
## Summary
- add an LLVM scaffolding backend with target triple support and hook it into the CLI `--llvm` mode
- expose helper APIs for backend consumers and expand backend regression coverage
- refresh documentation, roadmap notes, and CLI snippets to capture the typed IR contract and diagnostics playbook updates

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68db1eb20d24833087637fd13c4d31e8