### PR TITLE
Model record layout and effect metadata

### DIFF
--- a/src/ir/analysis.rs
+++ b/src/ir/analysis.rs
@@ -1,0 +1,54 @@
+use std::collections::HashSet;
+
+use super::{Function, InstKind, Terminator, ValueId};
+
+#[derive(Debug, Default, Clone)]
+pub struct PurityReport {
+    pub pure_blocks: HashSet<crate::ir::BlockId>,
+    pub effectful_instructions: HashSet<ValueId>,
+}
+
+impl PurityReport {
+    pub fn is_block_pure(&self, id: crate::ir::BlockId) -> bool {
+        self.pure_blocks.contains(&id)
+    }
+
+    pub fn is_instruction_effectful(&self, id: ValueId) -> bool {
+        self.effectful_instructions.contains(&id)
+    }
+}
+
+pub fn analyze_function_purity(function: &Function) -> PurityReport {
+    let mut pure_blocks = HashSet::new();
+    let mut effectful_insts = HashSet::new();
+
+    for block in &function.blocks {
+        let mut block_pure = true;
+        for inst in &block.instructions {
+            let mut effectful = !inst.effects.is_empty();
+            if matches!(inst.kind, InstKind::Call { .. }) && inst.effects.is_empty() {
+                // conservatively assume external calls without metadata are effectful
+                effectful = true;
+            }
+            if effectful {
+                block_pure = false;
+                effectful_insts.insert(inst.id);
+            }
+        }
+
+        if block_pure && is_pure_terminator(&block.terminator) {
+            pure_blocks.insert(block.id);
+        }
+    }
+
+    PurityReport {
+        pure_blocks,
+        effectful_instructions: effectful_insts,
+    }
+}
+
+fn is_pure_terminator(term: &Terminator) -> bool {
+    match term {
+        Terminator::Return(_) | Terminator::Branch { .. } | Terminator::Jump(_) => true,
+    }
+}

--- a/src/tests/backend_tests.rs
+++ b/src/tests/backend_tests.rs
@@ -217,7 +217,8 @@ fn build() -> Data {
     .expect("backend output");
 
     let ir = output.as_str();
-    assert!(ir.contains("define ptr @build()"));
-    assert!(ir.contains("call ptr @__mica_record_stub(i64 %0)"));
-    assert!(ir.contains("ret ptr %1"));
+    assert!(ir.contains("%record.Data = type { i64 }"));
+    assert!(ir.contains("define %record.Data @build()"));
+    assert!(ir.contains("insertvalue %record.Data"));
+    assert!(ir.contains("ret %record.Data %"));
 }


### PR DESCRIPTION
## Summary
- teach the lowering and IR type table about concrete record layouts, carrying field offsets and associating type aliases for reuse
- enrich instructions with effect metadata and add a basic purity analysis while teaching the LLVM/text backends to emit real struct types and aggregate literals
- expand backend and semantics tests to cover record handling, effect propagation, and capability diagnostics regressions

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dc09d75fc88330a1f81db85e4e7e74