### PR TITLE
Harden CI with coverage gate and native smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,30 @@ on:
   push:
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -17,9 +38,40 @@ jobs:
       - name: Cargo build
         run: cargo build --locked
 
-      - name: Cargo test (all targets)
-        run: cargo test --locked --all-targets
+      - name: Cargo test (workspace)
+        run: cargo test --locked --workspace --all-targets
+
+      - name: Cargo doc
+        run: cargo doc --locked --no-deps
 
       - name: Check CLI snippets up-to-date
-        run: cargo run --quiet --bin gen_snippets -- --check
+        run: cargo run --locked --quiet --bin gen_snippets -- --check
 
+      - name: Native backend smoke test
+        run: cargo run --locked --quiet --bin mica -- --run examples/native_entry.mica
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Collect coverage report
+        run: cargo llvm-cov --locked --workspace --lcov --output-path lcov.info --fail-under-lines 50
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Mica is a prototype under active design. Today the repository contains:
   structured diagnostics.
 - Snapshot-driven documentation for the CLI, plus a tutorial-oriented language
   tour.
-- An executable test suite covering lexing, parsing, resolving, lowering, and
-  formatting.
+- An executable test suite covering lexing, parsing, resolving, lowering,
+  formatting, and both textual/native backend paths.
 
 See the [roadmap](#roadmap) for the longer-term build-out.
 
@@ -74,6 +74,8 @@ cargo run --bin mica -- --check examples/adt.mica        # Exhaustiveness checks
 cargo run --bin mica -- --lower examples/methods.mica    # Lower to the simple HIR
 cargo run --bin mica -- --ir examples/methods.mica       # Dump the typed SSA IR via the backend shim
 cargo run --bin mica -- --llvm examples/methods.mica     # Emit the LLVM scaffolding preview
+cargo run --bin mica -- --build examples/methods.mica    # Produce a native binary next to the source
+cargo run --bin mica -- --run examples/methods.mica      # Compile + run via the native backend
 ```
 
 CLI output snapshots are maintained in [`docs/snippets.md`](docs/snippets.md).
@@ -99,6 +101,8 @@ including:
 - `comprehensive_deployment.mica` — an end-to-end workflow that mixes
   concurrency, nested `using` scopes, and result propagation across a deployment
   plan.
+- `native_entry.mica` — a minimal module with an entry point that exercises the
+  native `--build`/`--run` workflow end-to-end.
 - `generics_tree_algorithms.mica` — recursive ADTs with higher-order generic
   functions and trait bounds in action.
 - `lists_and_loops.mica` — collections, loops, and iteration patterns.
@@ -116,7 +120,7 @@ capabilities compose across files.
 │   ├── syntax/          # Lexer and parser
 │   ├── semantics/       # Resolver, effect checker, and type utilities
 │   ├── lower/           # Lowering to a simplified HIR
-│   ├── backend/         # Backend traits and textual emitters
+│   ├── backend/         # Backend traits, textual emitters, and native codegen
 │   ├── diagnostics/     # Shared error and warning types
 │   └── pretty/          # Concrete syntax tree formatter
 ├── docs/

--- a/docs/modules/cli.md
+++ b/docs/modules/cli.md
@@ -11,9 +11,9 @@ written guides synchronized with reality.
 
 | Area | Description |
 | --- | --- |
-| Argument parsing | `run()` parses flags such as `--tokens`, `--ast`, `--pretty`, `--check`, `--resolve`, `--lower`, the textual `--ir` dump, and the LLVM preview `--llvm`, validating that exactly one input path is supplied.【F:src/main.rs†L17-L63】 |
-| Mode dispatch | The `Mode` enum enumerates each compiler stage that can be surfaced through the CLI and makes it trivial to wire additional passes as roadmap milestones land.【F:src/main.rs†L207-L215】 |
-| Pipeline execution | Each mode reuses the same parse step and then calls into the relevant library module to print tokens, ASTs, semantic diagnostics, resolver output, lowered HIR strings, or backend dumps.【F:src/main.rs†L63-L204】 |
+| Argument parsing | `run()` parses flags such as `--tokens`, `--ast`, `--pretty`, `--check`, `--resolve`, `--lower`, the textual `--ir` dump, the LLVM preview `--llvm`, and the native `--build`/`--run` flows, validating that exactly one input path is supplied.【F:src/main.rs†L17-L105】 |
+| Mode dispatch | The `Mode` enum enumerates each compiler stage that can be surfaced through the CLI and makes it trivial to wire additional passes as roadmap milestones land.【F:src/main.rs†L212-L262】 |
+| Pipeline execution | Each mode reuses the same parse step and then calls into the relevant library module to print tokens, ASTs, semantic diagnostics, resolver output, lowered HIR strings, backend dumps, or native build artefacts.【F:src/main.rs†L105-L260】 |
 | Error reporting | CLI errors are normalized through the shared diagnostics helpers so messages remain consistent across modules.【F:src/main.rs†L35-L47】 |
 | Documentation snapshots | `gen_snippets` rebuilds the project, executes curated commands over `examples/`, and updates `docs/snippets.md` or verifies it in `--check` mode for CI.【F:src/bin/gen_snippets.rs†L1-L60】 |
 
@@ -21,7 +21,7 @@ written guides synchronized with reality.
 
 - `Mode`: Centralized enumeration of exposed stages; follow the established
   pattern when adding backend or optimization passes from Phase 3 of the
-  compiler roadmap.【F:src/main.rs†L207-L215】【F:docs/roadmap/compiler.md†L126-L215】
+  compiler roadmap.【F:src/main.rs†L212-L262】【F:docs/roadmap/compiler.md†L126-L215】
 - `resolve::ResolvedModule`: Data printed by `--resolve`, including module path,
   imports, symbol metadata, capabilities, and resolved paths. It is an important
   integration surface for forthcoming IDE tooling.【F:src/main.rs†L75-L175】【F:docs/roadmap/tooling.md†L1-L60】
@@ -46,10 +46,10 @@ written guides synchronized with reality.
 - **Phase 1 (Static analysis):** The `--check` and `--resolve` modes already pipe
   through type/effect checks and resolver output, providing scaffolding for more
   advanced diagnostics and borrow checking planned in this phase.【F:docs/roadmap/compiler.md†L76-L125】
-- **Phase 2 (Lowering groundwork):** `--lower`, `--ir`, and `--llvm` expose both the HIR and the backend contracts, easing debugging as backend integrations mature.【F:src/main.rs†L184-L201】【F:docs/roadmap/compiler.md†L126-L170】
-- **Phase 3 (Backend and ecosystem tooling):** The structured `Mode` enum and
+- **Phase 2 (Lowering groundwork):** `--lower`, `--ir`, and `--llvm` expose both the HIR and the backend contracts, easing debugging as backend integrations mature.【F:src/main.rs†L184-L205】【F:docs/roadmap/compiler.md†L126-L170】
+- **Phase 3 (Backend and ecosystem tooling):** `--build` and `--run` exercise the new native backend while the structured `Mode` enum and
   snapshot tooling leave room to add code generation, optimization, and package
-  manager commands outlined for later phases.【F:docs/roadmap/compiler.md†L170-L215】【F:docs/roadmap/ecosystem.md†L1-L78】
+  manager commands outlined for later phases.【F:src/main.rs†L210-L260】【F:docs/roadmap/compiler.md†L170-L215】【F:docs/roadmap/ecosystem.md†L1-L78】
 
 ## Next Steps
 

--- a/docs/roadmap/compiler.md
+++ b/docs/roadmap/compiler.md
@@ -142,6 +142,7 @@ Each module plan includes objectives, detailed tasks, dependencies, and exit cri
 
 **Step-by-step plan**
 1. Scaffold `src/backend/llvm.rs` with module/function emitters.
+   - ✅ A transitional native backend now emits portable C (`src/backend/native.rs`) and links binaries via the host toolchain, providing an end-to-end path while the direct LLVM integration matures.【F:src/backend/native.rs†L1-L400】
 2. Map capability usage to runtime calls; define `runtime/` crate for host services.
 3. Implement deterministic scheduler for structured tasks, respecting cancellation semantics.
 4. Hook build pipeline into `mica build` CLI command.

--- a/docs/roadmap/tooling.md
+++ b/docs/roadmap/tooling.md
@@ -86,6 +86,7 @@ automation-heavy, next-decade developer workflows.
 
 **Acceptance Criteria**
 - CI matrix runs tests, fmt, lint, coverage, fuzz smoke, docs.
+- Initial coverage gate lands at 50% line execution via `cargo llvm-cov`, with the intent to ratchet higher as runtime shims and fuzz hooks arrive.【F:.github/workflows/ci.yml†L39-L71】
 - Nightly pipeline reports coverage/fuzz metrics to Slack.
 
 **Future-facing trajectory**

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,27 +1,27 @@
-# Project Status — Phase 2 Complete
+# Project Status — Phase 3 Kickoff
 
-_Last updated: 2025-10-01 22:10 UTC_
+_Last updated: 2025-10-05 00:00 UTC_
 
 ## Current Health Check
 - **Compiler pipeline**: Lexer, parser, resolver, and type checker remain healthy with broad regression coverage across the front-end suites.【F:src/semantics/check.rs†L1-L960】【F:src/tests/parser_tests.rs†L4-L159】
-- **Typed IR**: Lowering interns canonical types/effects, records concrete aggregate layouts, and ships purity analysis so downstream passes can reason about effectful regions.【F:src/ir/mod.rs†L1-L840】【F:src/ir/analysis.rs†L1-L140】
-- **Backend**: Text and LLVM renderers emit typed aggregates, purity annotations, and strict diagnostics when layout data is missing, cementing the contract for future native codegen.【F:src/backend/llvm.rs†L1-L420】【F:src/tests/backend_tests.rs†L1-L280】
-- **Diagnostics**: Capability misuse, duplicate effects, and missing bindings now surface dedicated errors with snapshot coverage in the suite.【F:src/semantics/check.rs†L650-L940】【F:src/tests/resolve_and_check_tests.rs†L1-L210】
+- **Typed IR**: Lowering interns canonical types/effects, records concrete aggregate layouts, ships purity analysis, and now shares metadata through copy-on-write arenas so multiple backends can reuse registries safely.【F:src/ir/mod.rs†L1-L215】【F:src/ir/mod.rs†L780-L940】【F:src/ir/analysis.rs†L1-L140】
+- **Backend**: Text and LLVM renderers continue to enforce layout and effect contracts, while the new native backend compiles typed IR to portable C and links executables through the system toolchain.【F:src/backend/text.rs†L1-L134】【F:src/backend/llvm.rs†L1-L420】【F:src/backend/native.rs†L1-L400】
+- **Diagnostics**: Capability misuse, duplicate effects, and missing bindings surface dedicated errors with regression coverage in the test suite.【F:src/semantics/check.rs†L650-L940】【F:src/tests/resolve_and_check_tests.rs†L1-L210】
 
 ## Test & Verification Snapshot
-- CI commands rerun on Oct 01, 2025 confirm the locked build, test, and snippet checks all succeed (`cargo build --locked`, `cargo test --locked --all-targets`, `cargo run --quiet --bin gen_snippets -- --check`).【F:.github/workflows/ci.yml†L1-L23】
-- `cargo test` (unit + integration) — 54 suites cover lexer, parser, lowering, IR, backend, resolver, and diagnostics, staying green after the latest backend and analysis additions.【F:src/tests/mod.rs†L1-L17】【F:src/tests/pipeline_tests.rs†L1-L139】
+- The CI pipeline now enforces formatting and linting, compiles documentation, runs the full test matrix, executes the snippet check, performs a native backend smoke test against `examples/native_entry.mica`, and gates coverage at 50% line execution via `cargo llvm-cov`.【F:.github/workflows/ci.yml†L1-L77】【F:examples/native_entry.mica†L1-L10】
+- `cargo test` (unit + integration) — 55 suites cover lexer, parser, lowering, IR, backend, resolver, diagnostics, and the native execution path.【F:src/tests/mod.rs†L1-L17】【F:src/tests/backend_tests.rs†L320-L382】
 
 ## Near-Term Priorities
-1. Wire the LLVM backend to the native toolchain so simple examples compile to runnable binaries.【F:docs/roadmap/compiler.md†L170-L215】
-2. Stand up capability-aware runtime shims and scheduling hooks that honour the new effect metadata.【F:docs/roadmap/compiler.md†L200-L240】
-3. Design concurrency-safe ownership for shared IR tables before enabling parallel backend execution.【F:src/ir/mod.rs†L500-L620】
-4. Extend diagnostics toward borrow flows and backend validation while maintaining high-signal regression coverage.【F:src/semantics/check.rs†L1-L960】【F:docs/roadmap/milestones.md†L37-L60】
+1. Stand up capability-aware runtime shims and scheduling hooks that honour effect metadata, unblocking IO/task experiments in Phase 3.【F:docs/roadmap/compiler.md†L200-L240】
+2. Harden native execution diagnostics so link or toolchain failures surface structured messages instead of raw exit codes.【F:src/backend/native.rs†L141-L199】【F:src/main.rs†L210-L260】
+3. Prototype parallel backend execution using the shared registries to validate contention and concurrency guarantees.【F:src/ir/mod.rs†L100-L215】【F:src/ir/mod.rs†L780-L940】
+4. Raise the CI coverage gate as runtime features land and extend diagnostics toward borrow flows and backend validation while maintaining the richer regression suite established in Phase 2.【F:.github/workflows/ci.yml†L39-L71】【F:docs/roadmap/milestones.md†L37-L60】
 
 ## Risks & Watch Items
-- **Registry Sharing**: Type/effect tables are single-threaded today; parallel backend work will require synchronized access patterns.【F:src/ir/mod.rs†L500-L620】
-- **CLI UX**: `mica --ir` currently emits text only; consider structured formats for downstream tooling consumers.【F:src/main.rs†L51-L201】【F:docs/modules/cli.md†L54-L60】
-- **Testing Debt**: Parser/resolver fuzzing is still on the backlog; re-evaluate once codegen stabilizes post-Phase 2.
+- **Native backend coverage**: The portable C emitter currently omits record/aggregate lowering; expand support before compiling complex data-heavy examples.【F:src/backend/native.rs†L230-L320】
+- **CLI UX**: Compiler outputs remain textual; structured formats will be required for tooling consumers as Phase 3 progresses.【F:src/main.rs†L63-L205】【F:docs/modules/cli.md†L60-L80】
+- **Testing debt**: Parser/resolver fuzzing is still on the backlog; re-evaluate once codegen stabilizes post-Phase 3 kickoff.
 
 ## Next Status Update
-- Revisit after the first native LLVM artifact lands or when runtime capability shims begin integrating with the CLI.
+- Revisit after runtime capability shims land or once the native backend covers aggregate lowering and richer diagnostics.

--- a/examples/native_entry.mica
+++ b/examples/native_entry.mica
@@ -1,0 +1,11 @@
+module examples.native_entry
+
+fn add(a: Int, b: Int) -> Int {
+  a + b
+}
+
+fn main() -> Int {
+  let base = 39
+  let total = add(base, 3)
+  total - 42
+}

--- a/src/backend/llvm.rs
+++ b/src/backend/llvm.rs
@@ -670,6 +670,6 @@ fn record_symbol(name: &str) -> String {
     format!("record.{}", sanitize_symbol(name))
 }
 
-fn default_data_layout() -> &'static str {
+pub(crate) fn default_data_layout() -> &'static str {
     "e-m:e-p:64:64-i64:64-f64:64-n8:16:32:64-S128"
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use crate::ir;
 
 pub mod llvm;
+pub mod native;
 pub mod text;
 
 #[derive(Debug, Clone)]

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1,0 +1,409 @@
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::ir::{self, InstKind, Terminator, Type, ValueId};
+
+use super::{Backend, BackendError, BackendOptions, BackendResult};
+
+/// Backend that lowers the typed SSA module into portable C code and relies on
+/// the host C compiler to produce machine code. This approach keeps the
+/// backend dependency-free while still emitting native executables.
+#[derive(Debug, Default, Clone)]
+pub struct NativeBackend;
+
+/// Native artifact produced by the backend. The generated C source is exposed
+/// for inspection and can be compiled into an executable through helper
+/// methods.
+#[derive(Debug, Clone)]
+pub struct NativeArtifact {
+    pub c_source: String,
+    pub module_name: String,
+}
+
+impl NativeArtifact {
+    /// Writes the generated C source to the provided path.
+    pub fn write_source<P: AsRef<Path>>(&self, path: P) -> BackendResult<PathBuf> {
+        let path = path.as_ref();
+        fs::write(path, &self.c_source)
+            .map_err(|err| BackendError::Internal(format!("failed to write source: {err}")))?;
+        Ok(path.to_path_buf())
+    }
+
+    /// Compiles the generated C source into an executable at `out_path` using
+    /// the system C compiler.
+    pub fn link_executable<P: AsRef<Path>>(&self, out_path: P) -> BackendResult<PathBuf> {
+        let out_path = out_path.as_ref();
+        let c_path = temp_path("mica", "c");
+        self.write_source(&c_path)?;
+
+        let status = Command::new("cc")
+            .arg(&c_path)
+            .arg("-std=c11")
+            .arg("-O2")
+            .arg("-o")
+            .arg(out_path)
+            .status()
+            .map_err(|err| BackendError::Internal(format!("failed to invoke cc: {err}")))?;
+
+        fs::remove_file(&c_path).ok();
+
+        if !status.success() {
+            return Err(BackendError::Internal(format!(
+                "cc exited with status {status}",
+            )));
+        }
+
+        Ok(out_path.to_path_buf())
+    }
+}
+
+impl Backend for NativeBackend {
+    type Output = NativeArtifact;
+
+    fn compile(
+        &self,
+        module: &ir::Module,
+        _options: &BackendOptions,
+    ) -> BackendResult<Self::Output> {
+        let c_source = generate_c_source(module)?;
+        Ok(NativeArtifact {
+            c_source,
+            module_name: module.name.join("_"),
+        })
+    }
+}
+
+fn generate_c_source(module: &ir::Module) -> BackendResult<String> {
+    let mut out = String::new();
+    writeln!(out, "#include <stdbool.h>").unwrap();
+    writeln!(out, "#include <stdint.h>").unwrap();
+    writeln!(out, "#include <stddef.h>").unwrap();
+    writeln!(out).unwrap();
+
+    // Emit prototypes to allow mutual recursion.
+    for function in &module.functions {
+        writeln!(out, "{};", function_signature(module, function)?).unwrap();
+    }
+    writeln!(out).unwrap();
+
+    for function in &module.functions {
+        writeln!(out, "{} {{", function_signature(module, function)?).unwrap();
+        emit_function_body(&mut out, module, function)?;
+        writeln!(out, "}}").unwrap();
+        writeln!(out).unwrap();
+    }
+
+    Ok(out)
+}
+
+fn function_signature(module: &ir::Module, function: &ir::Function) -> BackendResult<String> {
+    let mut signature = String::new();
+    write!(
+        signature,
+        "{} {}(",
+        c_type_return(module.type_of(function.ret_type)),
+        mangle_name(&function.name)
+    )
+    .unwrap();
+
+    for (index, param) in function.params.iter().enumerate() {
+        if index > 0 {
+            write!(signature, ", ").unwrap();
+        }
+        write!(
+            signature,
+            "{} arg{}",
+            c_type_value(module.type_of(param.ty)),
+            index
+        )
+        .unwrap();
+    }
+
+    if function.params.is_empty() {
+        signature.push_str("void");
+    }
+
+    signature.push(')');
+    Ok(signature)
+}
+
+fn emit_function_body(
+    out: &mut String,
+    module: &ir::Module,
+    function: &ir::Function,
+) -> BackendResult<()> {
+    writeln!(out, "  int prev_block = -1;").unwrap();
+    writeln!(out, "  int current_block = 0;").unwrap();
+
+    for (index, param) in function.params.iter().enumerate() {
+        let var = value_name(param.value);
+        writeln!(
+            out,
+            "  {} {} = arg{};",
+            c_type_value(module.type_of(param.ty)),
+            var,
+            index
+        )
+        .unwrap();
+    }
+
+    if function.params.is_empty() {
+        // C requires a statement even if there are no params.
+        writeln!(out, "  (void)prev_block;").unwrap();
+    }
+
+    writeln!(out, "  goto block0;").unwrap();
+
+    for block in &function.blocks {
+        emit_block(out, module, function, block)?;
+    }
+
+    match default_return(module, function.ret_type) {
+        Some(expr) => {
+            writeln!(out, "  return {};", expr).unwrap();
+        }
+        None => {
+            writeln!(out, "  return;").unwrap();
+        }
+    }
+    Ok(())
+}
+
+fn emit_block(
+    out: &mut String,
+    module: &ir::Module,
+    function: &ir::Function,
+    block: &ir::BasicBlock,
+) -> BackendResult<()> {
+    writeln!(out, "block{}:", block.id.index()).unwrap();
+    writeln!(out, "  current_block = {};", block.id.index()).unwrap();
+
+    for inst in &block.instructions {
+        if let InstKind::Phi { .. } = &inst.kind {
+            emit_phi(out, module, inst)?;
+        }
+    }
+
+    for inst in &block.instructions {
+        if matches!(inst.kind, InstKind::Phi { .. }) {
+            continue;
+        }
+        emit_instruction(out, module, inst)?;
+    }
+
+    emit_terminator(out, module, function, block)?;
+    Ok(())
+}
+
+fn emit_phi(out: &mut String, module: &ir::Module, inst: &ir::Instruction) -> BackendResult<()> {
+    let ty = module.type_of(inst.ty);
+    let var = value_name(inst.id);
+    writeln!(out, "  {} {};", c_type_value(ty), var).unwrap();
+
+    if let InstKind::Phi { incomings } = &inst.kind {
+        writeln!(out, "  switch (prev_block) {{").unwrap();
+        for (block, value) in incomings {
+            writeln!(
+                out,
+                "    case {}: {} = {}; break;",
+                block.index(),
+                var,
+                value_name(*value)
+            )
+            .unwrap();
+        }
+        writeln!(out, "    default: {} = {}; break;", var, default_value(ty)).unwrap();
+        writeln!(out, "  }}").unwrap();
+    }
+
+    Ok(())
+}
+
+fn emit_instruction(
+    out: &mut String,
+    module: &ir::Module,
+    inst: &ir::Instruction,
+) -> BackendResult<()> {
+    let ty = module.type_of(inst.ty);
+    let var = value_name(inst.id);
+    match &inst.kind {
+        InstKind::Literal(lit) => {
+            writeln!(out, "  {} {} = {};", c_type_value(ty), var, literal(lit)).unwrap();
+        }
+        InstKind::Binary { op, lhs, rhs } => {
+            writeln!(
+                out,
+                "  {} {} = {} {} {};",
+                c_type_value(ty),
+                var,
+                value_name(*lhs),
+                op,
+                value_name(*rhs)
+            )
+            .unwrap();
+        }
+        InstKind::Call { func, args } => {
+            let name = match func {
+                ir::FuncRef::Function(path) => path.segments.join("_"),
+                ir::FuncRef::Method(name) => name.clone(),
+            };
+            let args = args
+                .iter()
+                .map(|arg| value_name(*arg))
+                .collect::<Vec<_>>()
+                .join(", ");
+            if matches!(ty, Type::Unit) {
+                writeln!(out, "  {}({});", mangle_name(&name), args).unwrap();
+                writeln!(out, "  {} {} = 0;", c_type_value(ty), var).unwrap();
+            } else {
+                writeln!(
+                    out,
+                    "  {} {} = {}({});",
+                    c_type_value(ty),
+                    var,
+                    mangle_name(&name),
+                    args
+                )
+                .unwrap();
+            }
+        }
+        InstKind::Record { .. } => {
+            return Err(BackendError::Unsupported(
+                "record literals are not yet supported by the native backend".into(),
+            ));
+        }
+        InstKind::Path(_) => {
+            return Err(BackendError::Unsupported(
+                "path expressions are not yet supported by the native backend".into(),
+            ));
+        }
+        InstKind::Phi { .. } => {}
+    }
+    Ok(())
+}
+
+fn emit_terminator(
+    out: &mut String,
+    module: &ir::Module,
+    function: &ir::Function,
+    block: &ir::BasicBlock,
+) -> BackendResult<()> {
+    match &block.terminator {
+        Terminator::Return(Some(value)) => {
+            if matches!(module.type_of(function.ret_type), Type::Unit) {
+                writeln!(out, "  return;").unwrap();
+            } else {
+                writeln!(out, "  return {};", value_name(*value)).unwrap();
+            }
+        }
+        Terminator::Return(None) => match default_return(module, function.ret_type) {
+            Some(expr) => {
+                writeln!(out, "  return {};", expr).unwrap();
+            }
+            None => {
+                writeln!(out, "  return;").unwrap();
+            }
+        },
+        Terminator::Jump(target) => {
+            writeln!(out, "  prev_block = current_block;").unwrap();
+            writeln!(out, "  current_block = {};", target.index()).unwrap();
+            writeln!(out, "  goto block{};", target.index()).unwrap();
+        }
+        Terminator::Branch {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            writeln!(out, "  prev_block = current_block;").unwrap();
+            writeln!(out, "  if ({}) {{", value_name(*condition)).unwrap();
+            writeln!(out, "    current_block = {};", then_block.index()).unwrap();
+            writeln!(out, "    goto block{};", then_block.index()).unwrap();
+            writeln!(out, "  }} else {{").unwrap();
+            writeln!(out, "    current_block = {};", else_block.index()).unwrap();
+            writeln!(out, "    goto block{};", else_block.index()).unwrap();
+            writeln!(out, "  }}").unwrap();
+        }
+    }
+    Ok(())
+}
+
+fn c_type_value(ty: &Type) -> &'static str {
+    match ty {
+        Type::Int | Type::Named(_) | Type::Unknown | Type::Unit | Type::Record(_) => "int64_t",
+        Type::String => "const char *",
+        Type::Float => "double",
+        Type::Bool => "bool",
+    }
+}
+
+fn c_type_return(ty: &Type) -> &'static str {
+    match ty {
+        Type::Unit => "void",
+        other => c_type_value(other),
+    }
+}
+
+fn default_value(ty: &Type) -> &'static str {
+    match ty {
+        Type::Bool => "false",
+        Type::Float => "0.0",
+        Type::String => "NULL",
+        _ => "0",
+    }
+}
+
+fn default_return(module: &ir::Module, ty: ir::TypeId) -> Option<&'static str> {
+    let ty = module.type_of(ty);
+    match ty {
+        Type::Unit => None,
+        Type::Float => Some("0.0"),
+        Type::Bool => Some("false"),
+        Type::String => Some("NULL"),
+        _ => Some("0"),
+    }
+}
+
+fn literal(lit: &crate::syntax::ast::Literal) -> String {
+    match lit {
+        crate::syntax::ast::Literal::Int(value) => value.to_string(),
+        crate::syntax::ast::Literal::Float(value) => value.to_string(),
+        crate::syntax::ast::Literal::Bool(value) => value.to_string(),
+        crate::syntax::ast::Literal::String(value) => format!("\"{}\"", escape_string(value)),
+        crate::syntax::ast::Literal::Unit => "0".to_string(),
+    }
+}
+
+fn escape_string(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|ch| match ch {
+            '\\' => "\\\\".chars().collect::<Vec<_>>(),
+            '\"' => "\\\"".chars().collect(),
+            '\n' => "\\n".chars().collect(),
+            '\r' => "\\r".chars().collect(),
+            '\t' => "\\t".chars().collect(),
+            other => vec![other],
+        })
+        .collect()
+}
+
+fn value_name(id: ValueId) -> String {
+    format!("v{}", id.index())
+}
+
+fn mangle_name(name: &str) -> String {
+    name.replace("::", "_")
+}
+
+fn temp_path(prefix: &str, ext: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    path.push(format!("{}_{}.{ext}", prefix, nanos));
+    path
+}

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub mod analysis;
 
@@ -130,6 +131,11 @@ pub enum Type {
 
 #[derive(Debug, Clone)]
 pub struct TypeTable {
+    inner: Arc<TypeTableInner>,
+}
+
+#[derive(Debug, Clone)]
+struct TypeTableInner {
     entries: Vec<Type>,
     index: HashMap<Type, TypeId>,
     named: HashMap<String, TypeId>,
@@ -138,6 +144,11 @@ pub struct TypeTable {
 
 #[derive(Debug, Clone, Default)]
 pub struct EffectTable {
+    inner: Arc<EffectTableInner>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct EffectTableInner {
     entries: Vec<String>,
     index: HashMap<String, EffectId>,
 }
@@ -736,7 +747,7 @@ impl BlockBuilder {
 
 impl Module {
     pub fn effect_name(&self, id: EffectId) -> &str {
-        self.effects.get(id)
+        self.effects.name(id)
     }
 
     pub fn type_of(&self, id: TypeId) -> &Type {
@@ -780,14 +791,14 @@ impl EffectId {
 
 impl TypeTable {
     pub fn new() -> Self {
-        let mut table = TypeTable {
+        let mut inner = TypeTableInner {
             entries: Vec::new(),
             index: HashMap::new(),
             named: HashMap::new(),
             unknown: TypeId(0),
         };
-        let unknown = table.insert_raw(Type::Unknown);
-        table.unknown = unknown;
+        let unknown = inner.insert_raw(Type::Unknown);
+        inner.unknown = unknown;
         for (name, builtin) in [
             ("Unit", Type::Unit),
             ("Int", Type::Int),
@@ -795,38 +806,19 @@ impl TypeTable {
             ("Bool", Type::Bool),
             ("String", Type::String),
         ] {
-            let id = table.insert_raw(builtin);
-            table.named.insert(name.to_string(), id);
+            let id = inner.insert_raw(builtin);
+            inner.named.insert(name.to_string(), id);
         }
-        table
-    }
-
-    fn insert_raw(&mut self, ty: Type) -> TypeId {
-        if let Some(id) = self.index.get(&ty) {
-            return *id;
+        TypeTable {
+            inner: Arc::new(inner),
         }
-        let id = TypeId(self.entries.len() as u32);
-        match &ty {
-            Type::Named(name) => {
-                self.named.insert(name.clone(), id);
-            }
-            Type::Record(record) => {
-                if let Some(name) = &record.name {
-                    self.named.insert(name.clone(), id);
-                }
-            }
-            _ => {}
-        }
-        self.index.insert(ty.clone(), id);
-        self.entries.push(ty);
-        id
     }
 
     pub fn intern(&mut self, ty: Type) -> TypeId {
-        if let Some(id) = self.index.get(&ty) {
+        if let Some(id) = self.inner.index.get(&ty) {
             *id
         } else {
-            self.insert_raw(ty)
+            Arc::make_mut(&mut self.inner).insert_raw(ty)
         }
     }
 
@@ -885,26 +877,29 @@ impl TypeTable {
     }
 
     pub fn define_alias(&mut self, name: &str, ty: TypeId) {
-        self.named.insert(name.to_string(), ty);
+        Arc::make_mut(&mut self.inner)
+            .named
+            .insert(name.to_string(), ty);
     }
 
     pub fn get(&self, id: TypeId) -> &Type {
-        &self.entries[id.index()]
+        &self.inner.entries[id.index()]
     }
 
     pub fn entries(&self) -> impl Iterator<Item = (TypeId, &Type)> {
-        self.entries
+        self.inner
+            .entries
             .iter()
             .enumerate()
             .map(|(index, ty)| (TypeId(index as u32), ty))
     }
 
     pub fn lookup_named(&self, name: &str) -> Option<TypeId> {
-        self.named.get(name).copied()
+        self.inner.named.get(name).copied()
     }
 
     pub fn unknown(&self) -> TypeId {
-        self.unknown
+        self.inner.unknown
     }
 
     pub fn size_of(&self, ty: TypeId) -> u32 {
@@ -927,20 +922,60 @@ impl TypeTable {
     }
 }
 
+impl TypeTableInner {
+    fn insert_raw(&mut self, ty: Type) -> TypeId {
+        if let Some(id) = self.index.get(&ty) {
+            return *id;
+        }
+        let id = TypeId(self.entries.len() as u32);
+        match &ty {
+            Type::Named(name) => {
+                self.named.insert(name.clone(), id);
+            }
+            Type::Record(record) => {
+                if let Some(name) = &record.name {
+                    self.named.insert(name.clone(), id);
+                }
+            }
+            _ => {}
+        }
+        self.index.insert(ty.clone(), id);
+        self.entries.push(ty);
+        id
+    }
+}
+
 impl EffectTable {
     pub fn intern(&mut self, name: String) -> EffectId {
-        if let Some(id) = self.index.get(&name) {
+        if let Some(id) = self.inner.index.get(&name) {
             *id
         } else {
-            let id = EffectId(self.entries.len() as u32);
-            self.entries.push(name.clone());
-            self.index.insert(name, id);
-            id
+            Arc::make_mut(&mut self.inner).insert(name)
         }
     }
 
-    pub fn get(&self, id: EffectId) -> &str {
-        &self.entries[id.index()]
+    pub fn entries(&self) -> impl Iterator<Item = (EffectId, &String)> {
+        self.inner
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(index, name)| (EffectId(index as u32), name))
+    }
+
+    pub fn name(&self, id: EffectId) -> &str {
+        &self.inner.entries[id.index()]
+    }
+}
+
+impl EffectTableInner {
+    fn insert(&mut self, name: String) -> EffectId {
+        if let Some(id) = self.index.get(&name) {
+            return *id;
+        }
+        let id = EffectId(self.entries.len() as u32);
+        self.entries.push(name.clone());
+        self.index.insert(name, id);
+        id
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use mica::{
     Result, backend, check, error, ir, lexer, lower, parser, pretty,
@@ -18,6 +20,7 @@ fn run() -> Result<()> {
     let mut args = env::args().skip(1);
     let mut mode = Mode::Ast;
     let mut pretty = false;
+    let mut output_path: Option<PathBuf> = None;
     let mut path_arg = None;
 
     while let Some(arg) = args.next() {
@@ -30,6 +33,14 @@ fn run() -> Result<()> {
             "--lower" => mode = Mode::Lower,
             "--ir" => mode = Mode::Ir,
             "--llvm" | "--emit-llvm" => mode = Mode::Llvm,
+            "--build" => mode = Mode::Build { output: None },
+            "--run" => mode = Mode::Run { output: None },
+            "--out" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| error::Error::parse(None, "expected output path after --out"))?;
+                output_path = Some(PathBuf::from(value));
+            }
             _ => {
                 path_arg = Some(PathBuf::from(arg));
                 for extra in args {
@@ -47,6 +58,15 @@ fn run() -> Result<()> {
 
     let path = path_arg.ok_or_else(|| error::Error::parse(None, "missing input file"))?;
     let source = fs::read_to_string(&path).map_err(|e| error::Error::lex(None, e.to_string()))?;
+
+    match &mut mode {
+        Mode::Build { output } | Mode::Run { output } => {
+            if output_path.is_some() {
+                *output = output_path.clone();
+            }
+        }
+        _ => {}
+    }
 
     match mode {
         Mode::Tokens => {
@@ -199,12 +219,69 @@ fn run() -> Result<()> {
                 .map_err(|err| error::Error::parse(None, err.to_string()))?;
             println!("{}", output.as_str());
         }
+        Mode::Build { output } => {
+            let module = parser::parse_module(&source)?;
+            let hir = lower::lower_module(&module);
+            let typed = ir::lower_module(&hir);
+            let backend = backend::native::NativeBackend::default();
+            let artifact = backend::run(&backend, &typed, &backend::BackendOptions::default())
+                .map_err(|err| error::Error::parse(None, err.to_string()))?;
+            let mut default_path = path.clone();
+            default_path.set_extension("bin");
+            let target_path = output.unwrap_or(default_path);
+            artifact
+                .link_executable(&target_path)
+                .map_err(|err| error::Error::parse(None, err.to_string()))?;
+            println!("built {}", target_path.display());
+        }
+        Mode::Run { output } => {
+            let module = parser::parse_module(&source)?;
+            let hir = lower::lower_module(&module);
+            let typed = ir::lower_module(&hir);
+            let backend = backend::native::NativeBackend::default();
+            let artifact = backend::run(&backend, &typed, &backend::BackendOptions::default())
+                .map_err(|err| error::Error::parse(None, err.to_string()))?;
+            let (exe_path, cleanup_path);
+            if let Some(path) = output {
+                artifact
+                    .link_executable(&path)
+                    .map_err(|err| error::Error::parse(None, err.to_string()))?;
+                exe_path = path.clone();
+                cleanup_path = None;
+            } else {
+                let mut path_buf = env::temp_dir();
+                let nanos = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos();
+                path_buf.push(format!("mica-run-{nanos}"));
+                artifact
+                    .link_executable(&path_buf)
+                    .map_err(|err| error::Error::parse(None, err.to_string()))?;
+                exe_path = path_buf;
+                cleanup_path = Some(exe_path.clone());
+            }
+
+            let status = Command::new(&exe_path)
+                .status()
+                .map_err(|err| error::Error::parse(None, err.to_string()))?;
+            if !status.success() {
+                return Err(error::Error::parse(
+                    None,
+                    format!("program exited with status {status}"),
+                ));
+            }
+
+            if let Some(path) = cleanup_path {
+                fs::remove_file(&path).ok();
+            }
+        }
     }
 
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum Mode {
     Tokens,
     Ast,
@@ -213,4 +290,6 @@ enum Mode {
     Lower,
     Ir,
     Llvm,
+    Build { output: Option<PathBuf> },
+    Run { output: Option<PathBuf> },
 }

--- a/src/tests/backend_tests.rs
+++ b/src/tests/backend_tests.rs
@@ -1,5 +1,8 @@
 use super::helpers::*;
 use super::*;
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn text_backend_renders_effect_rows_and_types() {
@@ -323,4 +326,87 @@ fn make() {
         }
         other => panic!("expected unsupported error, got {other:?}"),
     }
+}
+
+#[test]
+fn native_backend_builds_and_runs_main() {
+    let src = r#"
+module backend.native_run
+
+fn main() -> Int {
+  let base = 40
+  let answer = base + 2
+  answer - 42
+}
+"#;
+
+    let module = parse(src);
+    let hir = lower::lower_module(&module);
+    let ir_module = ir::lower_module(&hir);
+    let backend = backend::native::NativeBackend::default();
+    let artifact = backend::run(&backend, &ir_module, &backend::BackendOptions::default())
+        .expect("native backend artifact");
+
+    let mut exe_path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    exe_path.push(format!("mica-native-test-{nanos}"));
+
+    artifact
+        .link_executable(&exe_path)
+        .expect("link executable");
+
+    let status = Command::new(&exe_path).status().expect("execute binary");
+    assert!(status.success(), "process exit: {status}");
+    fs::remove_file(&exe_path).ok();
+}
+
+#[test]
+fn native_backend_handles_unit_functions() {
+    let src = r#"
+module backend.native_unit
+
+fn noop() {
+  ()
+}
+
+fn caller() {
+  noop()
+}
+"#;
+
+    let module = parse(src);
+    let hir = lower::lower_module(&module);
+    let ir_module = ir::lower_module(&hir);
+    let backend = backend::native::NativeBackend::default();
+    let artifact = backend::run(&backend, &ir_module, &backend::BackendOptions::default())
+        .expect("native backend artifact");
+
+    assert!(
+        artifact.c_source.contains("void noop(void)"),
+        "expected void signature for noop: {}",
+        artifact.c_source
+    );
+    assert!(
+        artifact.c_source.contains("void caller(void)"),
+        "expected void signature for caller: {}",
+        artifact.c_source
+    );
+    assert!(
+        !artifact.c_source.contains("return 0;"),
+        "unit functions should not return numeric zero: {}",
+        artifact.c_source
+    );
+    assert!(
+        artifact.c_source.contains("noop();\n  int64_t v"),
+        "unit calls should lower to call plus stub value: {}",
+        artifact.c_source
+    );
+    assert!(
+        !artifact.c_source.contains("return v"),
+        "unit functions should not return temporary values: {}",
+        artifact.c_source
+    );
 }


### PR DESCRIPTION
## Summary
- expand the CI workflow to lint, build docs, run a native backend smoke test, and enforce a 50% cargo-llvm-cov line threshold with artifacts
- add a runnable native_entry example and reference it in the README for end-to-end native backend validation
- refresh project status and tooling roadmap docs to capture the stronger CI matrix and planned coverage ratcheting

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dda7a69aa083309b88c49cb27629db