### PR TITLE
Fix clippy lint for FilesystemProvider registration

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -41,7 +41,7 @@ impl Runtime {
         let runtime = Runtime::new();
         runtime.register_provider(ConsoleProvider)?;
         runtime.register_provider(TimeProvider)?;
-        runtime.register_provider(FilesystemProvider::default())?;
+        runtime.register_provider(FilesystemProvider)?;
         Ok(runtime)
     }
 


### PR DESCRIPTION
## Summary
- register the filesystem capability provider without calling `default`

## Testing
- cargo clippy --workspace --all-targets --locked -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68e062de4d548330a2347cbed1f954f2