### PR TITLE
Document runtime telemetry APIs and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ documented entry points to make exploratory reading easier.
   regression tests.
 - [`docs/roadmap/`](docs/roadmap) — Milestones, design notes, and implementation
   plans.
+- [`docs/modules/runtime.md`](docs/modules/runtime.md) — Runtime orchestrator,
+  capability providers, and telemetry quickstart.
 - [`examples/`](examples) — Runnable programs referenced throughout the tour
   and used in integration tests.
 - [Issues](https://github.com/zesterer/mica/issues) — Discussion of active work,

--- a/docs/modules/runtime.md
+++ b/docs/modules/runtime.md
@@ -1,0 +1,57 @@
+# Runtime and Capability Providers
+
+## Scope
+
+The runtime orchestrator wires capability-aware tasks to concrete providers,
+executes their plans in a deterministic FIFO order, and captures telemetry for
+analysis or tooling consumption.【F:src/runtime/mod.rs†L1-L236】 This guide
+summarizes the stock providers, telemetry surface, and quick-start examples for
+embedding the runtime in host tools.
+
+## Default providers
+
+`Runtime::with_default_shims()` registers the console, time, filesystem, and
+environment providers so language tour examples and tests run without manual
+configuration.【F:src/runtime/mod.rs†L39-L64】 Each provider exposes a narrow API
+that mirrors the effect rows emitted by the compiler:
+
+- **Console (`io`)** – Supports `write_line`, emitting message events alongside a
+  unit return value.【F:src/runtime/mod.rs†L874-L905】
+- **Time (`time`)** – Provides `now_millis`, returning the current wall-clock time
+  as an integer and emitting a data event.【F:src/runtime/mod.rs†L1074-L1096】
+- **Filesystem (`fs`)** – Implements `read_to_string` and `write_string`. Reads
+  surface file contents, while writes accept `"path=contents"` payloads and emit
+  confirmation messages.【F:src/runtime/mod.rs†L909-L989】 Regression tests cover
+  both read and write paths to guarantee the provider's behaviour.【F:src/tests/runtime_tests.rs†L190-L276】
+- **Environment (`env`)** – Supports `get`, `set`, and `unset` for process
+  environment variables, surfacing data and message events as appropriate.【F:src/runtime/mod.rs†L993-L1068】 Tests assert that the provider round-trips values and cleans up state after execution.【F:src/tests/runtime_tests.rs†L278-L324】
+
+## Telemetry and JSON traces
+
+Every task execution yields a `RuntimeTrace` containing ordered events, per-event
+telemetry (sequence IDs and timestamps), and per-task metrics (durations,
+capability counts, spawned task totals).【F:src/runtime/mod.rs†L96-L352】 The
+trace can be serialized via `RuntimeTrace::to_json_string()` or produced directly
+through `Runtime::run_with_trace_json()` for downstream tooling.【F:src/runtime/mod.rs†L136-L155】【F:src/runtime/mod.rs†L440-L489】 Tests ensure the
+telemetry surface stays consistent and JSON encoding remains stable.【F:src/tests/runtime_tests.rs†L35-L188】【F:src/tests/runtime_tests.rs†L327-L384】
+
+## Example
+
+The snippet below demonstrates wiring the default providers, executing a task,
+and consuming the telemetry report:
+
+```rust
+use mica::runtime::{Runtime, RuntimeValue, TaskPlan, TaskSpec};
+
+let runtime = Runtime::with_default_shims()?;
+let spec = TaskSpec::new("main").with_capabilities(["io"]);
+let plan = TaskPlan::new().invoke("io", "write_line", Some(RuntimeValue::from("hello")));
+
+runtime.spawn(spec, plan);
+let trace = runtime.run_with_telemetry()?;
+assert_eq!(trace.events().len(), trace.telemetry().len());
+assert_eq!(trace.tasks()[0].capability_counts.get("io"), Some(&1));
+```
+
+Use `RuntimeTrace::to_json_string()` if you need a serialized representation for
+diagnostic dashboards or build artifacts.【F:src/runtime/mod.rs†L440-L489】

--- a/docs/status_summary.md
+++ b/docs/status_summary.md
@@ -14,7 +14,7 @@ _Last refreshed: 2025-10-06 00:00 UTC_
 - Typed SSA IR modules now share their type/effect registries through copy-on-write arenas so multiple backends can consume a module without cloning metadata, paving the way for parallel compilation.【F:src/ir/mod.rs†L100-L215】【F:src/ir/mod.rs†L780-L940】
 - Lowering and IR tests assert coverage for method desugaring, structured expressions, effect rows, return behaviour, and purity reporting so we know the pipeline handles the language surface we ship today.【F:src/tests/lowering_tests.rs†L1-L200】【F:src/tests/ir_tests.rs†L1-L360】
 - The native backend now emits portable C for typed IR, including record aggregates, drives the system toolchain to produce binaries, and is covered by executable regression tests alongside the text and LLVM preview emitters.【F:src/backend/native.rs†L1-L640】【F:src/tests/backend_tests.rs†L300-L420】
-- A capability-aware runtime orchestrator binds IO/time/filesystem providers, emits structured telemetry for every scheduled task, and now backs the CLI `--run` path by validating entrypoint capability coverage before native binaries execute.【F:src/runtime/mod.rs†L1-L520】【F:src/main.rs†L210-L320】【F:src/tests/runtime_tests.rs†L1-L260】
+- A capability-aware runtime orchestrator binds IO/time/filesystem providers, emits structured telemetry for every scheduled task, and now backs the CLI `--run` path by validating entrypoint capability coverage before native binaries execute.【F:src/runtime/mod.rs†L1-L236】【F:src/runtime/mod.rs†L874-L1096】【F:src/main.rs†L210-L320】【F:src/tests/runtime_tests.rs†L1-L384】
 
 ### Tooling and Developer Experience
 - The `mica` CLI now includes native `--build` and `--run` flows in addition to lexing, resolving, lowering, IR dumps, and the LLVM preview so contributors can execute examples end-to-end through the new backend, with runtime-backed capability validation prior to execution.【F:src/main.rs†L17-L320】
@@ -32,8 +32,8 @@ _Last refreshed: 2025-10-06 00:00 UTC_
 - ✅ **Purity analysis**: SSA functions include connectivity-aware purity reports that identify effect-free regions for future parallelization work.【F:src/ir/analysis.rs†L1-L140】【F:src/tests/ir_tests.rs†L280-L360】
 
 ## Next Focus Areas
-1. **Provider breadth**: Extend the baked-in runtime shims beyond console/time to cover filesystem and networking scenarios now that executables consult capability providers at run time.【F:src/backend/native.rs†L1-L720】【F:src/runtime/mod.rs†L1-L520】
-2. **Runtime telemetry**: Emit structured execution events from generated binaries so downstream tooling can visualize capability flows and task scheduling decisions.【F:src/runtime/mod.rs†L260-L480】【F:src/backend/native.rs†L1-L720】
+1. **Provider breadth**: Extend the baked-in runtime shims beyond console/time to cover filesystem and networking scenarios now that executables consult capability providers at run time.【F:src/backend/native.rs†L1-L720】【F:src/runtime/mod.rs†L874-L1096】
+2. **Runtime telemetry**: Emit structured execution events from generated binaries so downstream tooling can visualize capability flows and task scheduling decisions.【F:src/runtime/mod.rs†L96-L489】【F:src/backend/native.rs†L1-L720】
 3. **Parallel backend scaling**: Stress the new parallel compile driver across workspace-sized module sets and instrument contention hotspots ahead of broader backend scaling.【F:src/backend/mod.rs†L1-L200】【F:src/ir/mod.rs†L1-L1120】
 4. **Tooling APIs**: Layer higher-level CLI entry points over the resolver/IR JSON dumps to unblock IDE integrations and automated audits.【F:src/main.rs†L20-L360】【F:docs/modules/cli.md†L60-L80】
 

--- a/src/tests/runtime_tests.rs
+++ b/src/tests/runtime_tests.rs
@@ -172,6 +172,19 @@ fn runtime_produces_structured_telemetry() {
             .windows(2)
             .all(|pair| pair[0].sequence + 1 == pair[1].sequence)
     );
+
+    let tasks = trace.tasks();
+    assert_eq!(tasks.len(), 1, "expected exactly one task metric entry");
+    let metrics = &tasks[0];
+    assert_eq!(metrics.task, "main");
+    assert!(
+        metrics.event_count >= events.len(),
+        "task metrics should count at least as many events as observed"
+    );
+    assert!(
+        metrics.start_timestamp_micros.is_some(),
+        "task metrics should include a start timestamp"
+    );
 }
 
 #[test]
@@ -214,4 +227,158 @@ fn runtime_filesystem_provider_reads_files() {
         Some("filesystem contents"),
         "filesystem provider should surface file contents"
     );
+}
+
+#[test]
+fn runtime_filesystem_provider_writes_files() {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let runtime = Runtime::with_default_shims().expect("runtime setup");
+    let spec = TaskSpec::new("writer").with_capabilities(["fs"]);
+
+    let temp_dir = std::env::temp_dir();
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let path = temp_dir.join(format!("mica_runtime_write_{unique}.txt"));
+    let path_string = path.to_string_lossy().to_string();
+    let payload = format!("{}=runtime data", path_string);
+
+    let plan = TaskPlan::new()
+        .invoke("fs", "write_string", Some(RuntimeValue::from(payload)))
+        .invoke(
+            "fs",
+            "read_to_string",
+            Some(RuntimeValue::from(path_string.clone())),
+        );
+
+    runtime.spawn(spec, plan);
+    let events = runtime.run().expect("runtime events");
+
+    let observed = events.iter().find_map(|event| match event {
+        RuntimeEvent::CapabilityEvent {
+            capability,
+            event: CapabilityEvent::Data(RuntimeValue::String(data)),
+            ..
+        } if capability == "fs" => Some(data.clone()),
+        _ => None,
+    });
+
+    assert_eq!(
+        observed.as_deref(),
+        Some("runtime data"),
+        "filesystem provider should persist written data",
+    );
+
+    fs::remove_file(&path).ok();
+}
+
+#[test]
+fn runtime_environment_provider_round_trips_values() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let runtime = Runtime::with_default_shims().expect("runtime setup");
+    let spec = TaskSpec::new("env").with_capabilities(["env"]);
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let key = format!("MICA_RUNTIME_ENV_{unique}");
+
+    let plan = TaskPlan::new()
+        .invoke(
+            "env",
+            "set",
+            Some(RuntimeValue::from(format!("{key}=runtime"))),
+        )
+        .invoke("env", "get", Some(RuntimeValue::from(key.clone())))
+        .invoke("env", "unset", Some(RuntimeValue::from(key.clone())));
+
+    runtime.spawn(spec, plan);
+    let events = runtime.run().expect("runtime events");
+
+    let observed = events.iter().find_map(|event| match event {
+        RuntimeEvent::CapabilityEvent {
+            capability,
+            event: CapabilityEvent::Data(RuntimeValue::String(data)),
+            ..
+        } if capability == "env" => Some(data.clone()),
+        _ => None,
+    });
+
+    assert_eq!(
+        observed.as_deref(),
+        Some("runtime"),
+        "environment provider should surface stored values",
+    );
+
+    assert!(
+        std::env::var(&key).is_err(),
+        "environment variable should be unset after runtime execution",
+    );
+
+    unsafe {
+        std::env::remove_var(&key);
+    }
+}
+
+#[test]
+fn runtime_trace_reports_task_metrics_for_children() {
+    let runtime = Runtime::with_default_shims().expect("runtime setup");
+    let child_spec = TaskSpec::new("child").with_capabilities(["io"]);
+    let child_plan = TaskPlan::new().invoke("io", "write_line", Some(RuntimeValue::from("child")));
+    let parent_plan = TaskPlan::new()
+        .invoke("io", "write_line", Some(RuntimeValue::from("parent")))
+        .spawn(child_spec.clone(), child_plan);
+    let parent_spec = TaskSpec::new("parent").with_capabilities(["io"]);
+
+    runtime.spawn(parent_spec, parent_plan);
+    let trace = runtime
+        .run_with_telemetry()
+        .expect("runtime telemetry trace");
+
+    let tasks = trace.tasks();
+    assert_eq!(
+        tasks.len(),
+        2,
+        "expected metrics for parent and child tasks"
+    );
+
+    let parent_metrics = tasks
+        .iter()
+        .find(|metrics| metrics.task == "parent")
+        .expect("missing parent metrics");
+    assert_eq!(parent_metrics.spawned_tasks, 1);
+    assert_eq!(parent_metrics.capability_counts.get("io"), Some(&1));
+
+    let child_metrics = tasks
+        .iter()
+        .find(|metrics| metrics.task == "child")
+        .expect("missing child metrics");
+    assert_eq!(child_metrics.spawned_tasks, 0);
+    assert_eq!(child_metrics.capability_counts.get("io"), Some(&1));
+}
+
+#[test]
+fn runtime_trace_serializes_to_json() {
+    let runtime = Runtime::with_default_shims().expect("runtime setup");
+    let spec = TaskSpec::new("main").with_capabilities(["io"]);
+    let plan = TaskPlan::new().invoke("io", "write_line", Some(RuntimeValue::from("hello")));
+
+    runtime.spawn(spec, plan);
+    let json = runtime
+        .run_with_trace_json()
+        .expect("runtime should serialize trace");
+
+    assert!(json.trim_start().starts_with('{'));
+    assert!(json.trim_end().ends_with('}'));
+    assert!(json.contains("\"events\""));
+    assert!(json.contains("\"telemetry\""));
+    assert!(json.contains("\"tasks\""));
+    assert!(json.contains("\"task\":\"main\""));
+    assert!(json.contains("\"type\":\"task_started\""));
+    assert!(json.contains("\"capability_counts\":{\"io\":1"));
 }


### PR DESCRIPTION
## Summary
- add Rust doc examples for the runtime telemetry helpers and document the environment provider safety assumptions
- author a dedicated runtime module guide, link it from the README, and refresh the status summary citations to the new line locations

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo build --locked
- cargo test --locked --workspace --all-targets
- cargo doc --locked --no-deps
- cargo run --locked --quiet --bin gen_snippets -- --check
- cargo run --locked --quiet --bin mica -- --run examples/native_entry.mica


------
https://chatgpt.com/codex/tasks/task_e_68e0ade80f44833093ca5cb34cf44b82