### PR TITLE
Regenerate CLI snippets documentation

### DIFF
--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -1,13 +1,12 @@
 # CLI Snippets
 
-> Captured output from real CLI runs. Regenerate with `cargo run --bin gen_snippets`.
-
-These examples demonstrate the CLI surface. Each block was produced by running
-the listed command against the corresponding file in `examples/`.
+This page shows short outputs from the CLI for selected examples.
 
 ## Pretty AST (`--ast --pretty`)
+
 Command: `cargo run --bin mica -- --ast --pretty examples/adt.mica`
-```text
+
+```
 module demo.adt
 pub type Option[T] = Some(T) | None
 pub type Result[T, E] = Ok(T) | Err(E)
@@ -15,14 +14,18 @@ pub fn map_option[T, U](x: Option[T], f: fn(T) -> U) -> Option[U] { … }
 ```
 
 ## Exhaustiveness Check (`--check`)
+
 Command: `cargo run --bin mica -- --check examples/adt_match_nonexhaustive.mica`
-```text
+
+```
 warning: non-exhaustive match for Color: missing variants Green, Blue
 ```
 
 ## Lowered HIR (`--lower`)
+
 Command: `cargo run --bin mica -- --lower examples/methods.mica`
-```text
+
+```
 hir module demo.methods
 type Vec2 = Record([("x", Name("Int")), ("y", Name("Int"))])
 fn use_method(a, b)
@@ -30,8 +33,10 @@ fn use_method(a, b)
 ```
 
 ## Typed IR (`--ir`)
+
 Command: `cargo run --bin mica -- --ir examples/methods.mica`
-```text
+
+```
 module demo.methods
 
 fn use_method(a: Vec2, b: Vec2) -> Vec2
@@ -41,8 +46,10 @@ fn use_method(a: Vec2, b: Vec2) -> Vec2
 ```
 
 ## LLVM Scaffold (`--llvm`)
+
 Command: `cargo run --bin mica -- --llvm examples/methods.mica`
-```text
+
+```
 ; ModuleID = 'demo.methods'
 target datalayout = "e-m:e-p:64:64-i64:64-f64:64-n8:16:32:64-S128"
 
@@ -57,10 +64,11 @@ bb0:
 }
 ```
 
-## Concurrency Example (`--lower`)
 Command: `cargo run --bin mica -- --lower examples/spawn_await.mica`
-```text
+
+```
 hir module demo.concurrent
 fn fetch(u, net) !{net}
   await(spawn(http::get(u, net)))
 ```
+


### PR DESCRIPTION
## Summary
- regenerate the CLI snippet outputs in docs/snippets.md to match the latest generator output

## Testing
- cargo run --locked --quiet --bin gen_snippets -- --check

------
https://chatgpt.com/codex/tasks/task_e_68e1198818b48330ae672befa8ac8f1f