### PR TITLE
Add deterministic network fixtures and pipeline tooling

### DIFF
--- a/docs/roadmap/next-step.md
+++ b/docs/roadmap/next-step.md
@@ -1,24 +1,27 @@
 # Immediate Next Step Recommendation
 
-The Phase 1 semantics milestone is complete: the resolver now builds cross-module
-workspaces with capability metadata, and the checker validates signatures,
-effects, and pattern exhaustiveness through `mica --check`.
+Phase 2 is complete: the typed IR, backend surface area, diagnostics, and
+pureness analysis have shipped. Mica is now firmly executing the Phase 3
+"Backend & Runtime" milestone, where the focus shifts to production-ready
+runtimes, native code generation, and contributor tooling.
 
-With that foundation in place, focus on the early Phase 2 deliverables:
+With that context, the next actions should reinforce Phase 3 outcomes:
 
-1. **Define the typed IR contract.** Finalise the SSA-inspired layout, encode
-effect metadata, and begin lowering typed ASTs so later passes can reason about
-drops and scheduling.
-2. **Sketch backend integration.** Outline the LLVM-oriented backend scaffolding
-that will consume the IR, ensuring the lowering data model preserves sufficient
-provenance for code generation and runtime hooks.
-3. **Expand the diagnostics playbook.** Capture the semantics of the new checker
-errors, refresh CLI examples, and document wording expectations so tooling work
-can consume consistent output.
+1. **Broaden deterministic capability providers.** Extend the runtime’s stock
+   shims with filesystem coverage, deterministic network fixtures, and the
+   accompanying smoke tests so compiled programs can exercise richer IO while
+   preserving repeatability.
+2. **Surface richer telemetry.** Emit aggregated runtime summaries (tasks,
+   spawned children, capability usage) and JSON tooling snapshots so IDEs and
+   continuous integration jobs can reason about executions without re-parsing
+   logs.
+3. **Track backend parallelism limits.** Capture worker concurrency and module
+   scheduling metrics from the parallel backend harness to guide scaling
+   experiments and capacity planning.
+4. **Document the pipeline entry points.** Keep CLI references and developer
+   notes aligned with the new `--pipeline-json` command and runtime fixtures so
+   contributors can quickly reproduce the current system behaviour.
 
-Completing these items transitions the project into Phase 2 and sets up the SSA
-lowering, backend, and optimisation research that follow.
-
-_Status update:_ The typed IR guide now lives in `docs/modules/ir.md`, the LLVM
-scaffolding backend exports its contract via `mica --llvm`, and the CLI snippets
-showcase the richer pipeline so contributors can iterate confidently.
+Staying disciplined on these items keeps Phase 3 deliverables aligned: richer
+runtime coverage, observable compiler behaviour, and ergonomic tooling that can
+underpin the subsequent IDE-focused Phase 4 work.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -70,6 +70,8 @@ pub struct ParallelCompileReport<T> {
 pub struct ParallelCompileMetrics {
     pub total_duration: Duration,
     pub modules: Vec<ModuleCompileMetrics>,
+    pub worker_count: usize,
+    pub scheduled_modules: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -177,6 +179,8 @@ where
     let metrics = ParallelCompileMetrics {
         total_duration: start.elapsed(),
         modules: module_metrics,
+        worker_count,
+        scheduled_modules: modules.len(),
     };
 
     Ok(ParallelCompileReport { outputs, metrics })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod pretty;
 pub mod runtime;
 pub mod semantics;
 pub mod syntax;
+pub mod tooling;
 
 pub use diagnostics::error;
 pub use diagnostics::{Error, ErrorKind, Result};

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use mica::{
     resolve::{self, CapabilityScope, PathKind, SymbolCategory, SymbolScope},
     runtime,
     syntax::ast,
+    tooling,
 };
 
 fn main() {
@@ -54,6 +55,7 @@ impl CliArgs {
                 "--lower" => command = CommandKind::Lower,
                 "--ir" => command = CommandKind::Ir,
                 "--ir-json" => command = CommandKind::IrJson,
+                "--pipeline-json" => command = CommandKind::PipelineJson,
                 "--llvm" | "--emit-llvm" => command = CommandKind::Llvm,
                 "--build" => command = CommandKind::Build { output: None },
                 "--run" => command = CommandKind::Run { output: None },
@@ -116,6 +118,7 @@ enum CommandKind {
     Lower,
     Ir,
     IrJson,
+    PipelineJson,
     Llvm,
     Build { output: Option<PathBuf> },
     Run { output: Option<PathBuf> },
@@ -140,6 +143,7 @@ impl CommandKind {
             CommandKind::Lower => run_lower(&ctx),
             CommandKind::Ir => run_ir(&ctx),
             CommandKind::IrJson => run_ir_json(&ctx),
+            CommandKind::PipelineJson => run_pipeline_json(&ctx),
             CommandKind::Llvm => run_llvm(&ctx),
             CommandKind::Build { output } => run_build(&ctx, output),
             CommandKind::Run { output } => run_executable(&ctx, output),
@@ -315,6 +319,12 @@ fn run_ir_json(ctx: &CommandContext) -> Result<()> {
     let typed = ir::lower_module(&hir);
     let json = ir_module_to_json(&typed);
     println!("{}", json);
+    Ok(())
+}
+
+fn run_pipeline_json(ctx: &CommandContext) -> Result<()> {
+    let snapshot = tooling::PipelineSnapshot::capture(&ctx.source);
+    println!("{}", snapshot.to_json_string());
     Ok(())
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::env;
 use std::fs;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::backend::BackendError;
@@ -59,6 +59,7 @@ impl Runtime {
         runtime.register_provider(ConsoleProvider)?;
         runtime.register_provider(TimeProvider)?;
         runtime.register_provider(FilesystemProvider)?;
+        runtime.register_provider(NetworkProvider::default())?;
         runtime.register_provider(EnvProvider)?;
         Ok(runtime)
     }
@@ -437,8 +438,28 @@ impl RuntimeTrace {
         self.events
     }
 
+    /// Produces an aggregated summary capturing total tasks, events, spawned
+    /// children, and capability usage across the trace.
+    pub fn summary(&self) -> RuntimeTraceSummary {
+        let mut capability_totals: HashMap<String, usize> = HashMap::new();
+        let mut spawned = 0usize;
+        for metrics in &self.tasks {
+            spawned += metrics.spawned_tasks;
+            for (capability, count) in &metrics.capability_counts {
+                *capability_totals.entry(capability.clone()).or_insert(0) += *count;
+            }
+        }
+
+        RuntimeTraceSummary {
+            total_tasks: self.tasks.len(),
+            total_events: self.events.len(),
+            spawned_tasks: spawned,
+            capability_counts: capability_totals,
+        }
+    }
+
     /// Serializes the runtime trace into a JSON object containing the events,
-    /// telemetry timeline, and per-task metrics.
+    /// telemetry timeline, per-task metrics, and a summary section.
     ///
     /// # Examples
     ///
@@ -484,9 +505,20 @@ impl RuntimeTrace {
             json.push_str(&task_telemetry_to_json(metrics));
         }
         json.push(']');
+        json.push(',');
+        json.push_str("\"summary\":");
+        json.push_str(&runtime_trace_summary_to_json(&self.summary()));
         json.push('}');
         Ok(json)
     }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeTraceSummary {
+    pub total_tasks: usize,
+    pub total_events: usize,
+    pub spawned_tasks: usize,
+    pub capability_counts: HashMap<String, usize>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -623,6 +655,24 @@ fn task_telemetry_to_json(metrics: &TaskTelemetry) -> String {
     json.push(',');
     json.push_str("\"spawned_tasks\":");
     json.push_str(&metrics.spawned_tasks.to_string());
+    json.push('}');
+    json
+}
+
+fn runtime_trace_summary_to_json(summary: &RuntimeTraceSummary) -> String {
+    let mut json = String::new();
+    json.push('{');
+    json.push_str("\"total_tasks\":");
+    json.push_str(&summary.total_tasks.to_string());
+    json.push(',');
+    json.push_str("\"total_events\":");
+    json.push_str(&summary.total_events.to_string());
+    json.push(',');
+    json.push_str("\"spawned_tasks\":");
+    json.push_str(&summary.spawned_tasks.to_string());
+    json.push(',');
+    json.push_str("\"capability_counts\":");
+    json.push_str(&capability_counts_to_json(&summary.capability_counts));
     json.push('}');
     json
 }
@@ -988,6 +1038,127 @@ impl CapabilityProvider for FilesystemProvider {
             )),
         }
     }
+}
+
+#[derive(Debug, Default)]
+struct NetworkProvider;
+
+impl NetworkProvider {
+    fn load_fixture(&self, key: &str) -> Option<NetworkFixture> {
+        network_fixtures()
+            .read()
+            .expect("network fixtures poisoned")
+            .get(key)
+            .cloned()
+    }
+}
+
+impl CapabilityProvider for NetworkProvider {
+    fn name(&self) -> &str {
+        "net"
+    }
+
+    fn handle(&self, invocation: &CapabilityInvocation) -> Result<ProviderResponse, RuntimeError> {
+        match invocation.operation.as_str() {
+            "fetch" => {
+                let key = invocation
+                    .payload
+                    .as_ref()
+                    .and_then(|value| match value {
+                        RuntimeValue::String(value) => Some(value.clone()),
+                        _ => None,
+                    })
+                    .ok_or_else(|| {
+                        RuntimeError::provider_failure(
+                            self.name(),
+                            "fetch expects a string payload identifying a fixture",
+                        )
+                    })?;
+
+                let fixture = self.load_fixture(&key).ok_or_else(|| {
+                    RuntimeError::provider_failure(
+                        self.name(),
+                        format!("no fixture registered for '{key}'"),
+                    )
+                })?;
+
+                let mut response = ProviderResponse::new(RuntimeValue::from(fixture.body.clone()))
+                    .with_event(CapabilityEvent::Message(format!(
+                        "fixture {key} responded with status {}",
+                        fixture.status
+                    )))
+                    .with_event(CapabilityEvent::Data(RuntimeValue::from(i64::from(
+                        fixture.status,
+                    ))));
+
+                for (name, value) in fixture.sorted_headers() {
+                    response = response
+                        .with_event(CapabilityEvent::Message(format!("header {name}: {value}")));
+                }
+
+                Ok(response)
+            }
+            other => Err(RuntimeError::provider_failure(
+                self.name(),
+                format!("unsupported operation '{other}'"),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkFixture {
+    status: u16,
+    body: String,
+    headers: Vec<(String, String)>,
+}
+
+impl NetworkFixture {
+    pub fn new(status: u16, body: impl Into<String>) -> Self {
+        NetworkFixture {
+            status,
+            body: body.into(),
+            headers: Vec::new(),
+        }
+    }
+
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((name.into(), value.into()));
+        self
+    }
+
+    pub fn status(&self) -> u16 {
+        self.status
+    }
+
+    pub fn body(&self) -> &str {
+        &self.body
+    }
+
+    fn sorted_headers(&self) -> Vec<(String, String)> {
+        let mut headers = self.headers.clone();
+        headers.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+        headers
+    }
+}
+
+pub fn register_network_fixture(key: impl Into<String>, fixture: NetworkFixture) {
+    network_fixtures()
+        .write()
+        .expect("network fixtures poisoned")
+        .insert(key.into(), fixture);
+}
+
+pub fn reset_network_fixtures() {
+    network_fixtures()
+        .write()
+        .expect("network fixtures poisoned")
+        .clear();
+}
+
+fn network_fixtures() -> &'static RwLock<HashMap<String, NetworkFixture>> {
+    static FIXTURES: OnceLock<RwLock<HashMap<String, NetworkFixture>>> = OnceLock::new();
+    FIXTURES.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
 #[derive(Debug, Default)]

--- a/src/tests/backend_tests.rs
+++ b/src/tests/backend_tests.rs
@@ -542,6 +542,13 @@ fn parallel_backend_reports_metrics_for_many_modules() {
 
     assert_eq!(report.outputs.len(), modules.len());
     assert_eq!(report.metrics.modules.len(), modules.len());
+    let expected_workers = std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(1)
+        .min(modules.len())
+        .max(1);
+    assert_eq!(report.metrics.worker_count, expected_workers);
+    assert_eq!(report.metrics.scheduled_modules, modules.len());
     assert!(report.metrics.total_duration >= delay);
     assert!(
         report

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,3 +14,4 @@ mod pipeline_tests;
 mod pretty_tests;
 mod resolve_and_check_tests;
 mod runtime_tests;
+mod tooling_tests;

--- a/src/tests/tooling_tests.rs
+++ b/src/tests/tooling_tests.rs
@@ -1,0 +1,102 @@
+use crate::tooling::{MetricValue, PipelineSnapshot, StageStatus};
+
+#[test]
+fn pipeline_snapshot_reports_stage_metrics() {
+    let src = r#"
+module tooling.capture
+
+fn compute(x: Int, io: IO, net: Net) -> Int !{io, net} {
+  let doubled = x + x
+  doubled
+}
+"#;
+
+    let snapshot = PipelineSnapshot::capture(src);
+    assert_eq!(
+        snapshot.module_path(),
+        &["tooling".to_string(), "capture".to_string()]
+    );
+
+    let stages = snapshot.stages();
+    let names: Vec<&str> = stages.iter().map(|stage| stage.name()).collect();
+    assert_eq!(
+        names,
+        vec!["lexer", "parser", "resolve", "check", "lower", "ir"]
+    );
+
+    for stage in stages {
+        assert!(matches!(stage.status(), StageStatus::Success));
+    }
+
+    let resolve_stage = snapshot
+        .stages()
+        .iter()
+        .find(|stage| stage.name() == "resolve")
+        .expect("resolve stage present");
+    let capabilities = resolve_stage
+        .metrics()
+        .iter()
+        .find(|metric| metric.key() == "capabilities")
+        .expect("capability metric present");
+    match capabilities.value() {
+        MetricValue::List(values) => {
+            assert!(values.contains(&"io".to_string()));
+            assert!(values.contains(&"net".to_string()));
+        }
+        other => panic!("expected list metric, got {other:?}"),
+    }
+
+    let check_stage = snapshot
+        .stages()
+        .iter()
+        .find(|stage| stage.name() == "check")
+        .expect("check stage present");
+    let diagnostics = check_stage
+        .metrics()
+        .iter()
+        .find(|metric| metric.key() == "diagnostics")
+        .expect("diagnostics metric");
+    match diagnostics.value() {
+        MetricValue::Integer(count) => assert_eq!(*count, 0),
+        other => panic!("expected integer metric, got {other:?}"),
+    }
+}
+
+#[test]
+fn pipeline_snapshot_handles_parse_errors() {
+    let src = "module broken\nfn missing_brace(x: Int) {";
+    let snapshot = PipelineSnapshot::capture(src);
+
+    assert!(snapshot.module_path().is_empty());
+    let stages = snapshot.stages();
+    assert_eq!(
+        stages.len(),
+        2,
+        "only lexer and parser stages should be recorded"
+    );
+    assert!(matches!(stages[0].status(), StageStatus::Success));
+    assert!(matches!(stages[1].status(), StageStatus::Failed { .. }));
+}
+
+#[test]
+fn pipeline_snapshot_serializes_to_json() {
+    let src = r#"
+module tooling.json
+
+type Alias = Int
+
+fn identity(x: Int) -> Int {
+  x
+}
+"#;
+
+    let snapshot = PipelineSnapshot::capture(src);
+    let json = snapshot.to_json_string();
+
+    assert!(json.contains("\"module_path\""));
+    assert!(json.contains("\"stages\""));
+    assert!(json.contains("\"lexer\""));
+    assert!(json.contains("\"resolve\""));
+    assert!(json.contains("\"diagnostics\""));
+    assert!(json.contains("\"ok\":true"));
+}

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -1,0 +1,310 @@
+use crate::{
+    check, ir, lexer,
+    lower::{self, HItem},
+    parser, resolve,
+};
+
+#[derive(Debug, Clone)]
+pub struct PipelineSnapshot {
+    module_path: Vec<String>,
+    stages: Vec<PipelineStage>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PipelineStage {
+    name: &'static str,
+    status: StageStatus,
+    metrics: Vec<StageMetric>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StageStatus {
+    Success,
+    Failed { message: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct StageMetric {
+    key: &'static str,
+    value: MetricValue,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetricValue {
+    Integer(usize),
+    Text(String),
+    Bool(bool),
+    List(Vec<String>),
+}
+
+impl PipelineSnapshot {
+    pub fn capture(source: &str) -> Self {
+        let mut stages = Vec::new();
+        let mut module_path = Vec::new();
+
+        let tokens = match lexer::lex(source) {
+            Ok(tokens) => {
+                stages.push(
+                    PipelineStage::success("lexer")
+                        .with_metric("tokens", MetricValue::Integer(tokens.len())),
+                );
+                tokens
+            }
+            Err(err) => {
+                stages.push(PipelineStage::failed("lexer", err.to_string()));
+                return PipelineSnapshot {
+                    module_path,
+                    stages,
+                };
+            }
+        };
+
+        let module = match parser::parse_module(source) {
+            Ok(module) => {
+                module_path = module.name.clone();
+                stages.push(
+                    PipelineStage::success("parser")
+                        .with_metric("items", MetricValue::Integer(module.items.len()))
+                        .with_metric("tokens", MetricValue::Integer(tokens.len())),
+                );
+                module
+            }
+            Err(err) => {
+                stages.push(PipelineStage::failed("parser", err.to_string()));
+                return PipelineSnapshot {
+                    module_path,
+                    stages,
+                };
+            }
+        };
+
+        let resolved = resolve::resolve_module(&module);
+        let mut capability_names = resolved
+            .capabilities
+            .iter()
+            .map(|cap| cap.name.clone())
+            .collect::<Vec<_>>();
+        capability_names.sort();
+        stages.push(
+            PipelineStage::success("resolve")
+                .with_metric("imports", MetricValue::Integer(resolved.imports.len()))
+                .with_metric("capabilities", MetricValue::List(capability_names))
+                .with_metric(
+                    "diagnostics",
+                    MetricValue::Integer(resolved.diagnostics.len()),
+                ),
+        );
+
+        let check_result = check::check_module(&module);
+        stages.push(
+            PipelineStage::success("check")
+                .with_metric(
+                    "diagnostics",
+                    MetricValue::Integer(check_result.diagnostics.len()),
+                )
+                .with_metric("ok", MetricValue::Bool(check_result.diagnostics.is_empty())),
+        );
+
+        let lowered = lower::lower_module(&module);
+        let function_count = lowered
+            .items
+            .iter()
+            .filter(|item| matches!(item, HItem::Function(_)))
+            .count();
+        stages.push(
+            PipelineStage::success("lower")
+                .with_metric("functions", MetricValue::Integer(function_count))
+                .with_metric("items", MetricValue::Integer(lowered.items.len())),
+        );
+
+        let ir_module = ir::lower_module(&lowered);
+        let block_count: usize = ir_module
+            .functions
+            .iter()
+            .map(|func| func.blocks.len())
+            .sum();
+        let effect_count = ir_module.effects.entries().count();
+        stages.push(
+            PipelineStage::success("ir")
+                .with_metric("functions", MetricValue::Integer(ir_module.functions.len()))
+                .with_metric("blocks", MetricValue::Integer(block_count))
+                .with_metric("effects", MetricValue::Integer(effect_count)),
+        );
+
+        PipelineSnapshot {
+            module_path,
+            stages,
+        }
+    }
+
+    pub fn module_path(&self) -> &[String] {
+        &self.module_path
+    }
+
+    pub fn stages(&self) -> &[PipelineStage] {
+        &self.stages
+    }
+
+    pub fn to_json_string(&self) -> String {
+        let mut json = String::new();
+        json.push('{');
+        json.push_str("\"module_path\":[");
+        for (index, segment) in self.module_path.iter().enumerate() {
+            if index > 0 {
+                json.push(',');
+            }
+            json.push('"');
+            json.push_str(&escape_json_string(segment));
+            json.push('"');
+        }
+        json.push(']');
+        json.push(',');
+        json.push_str("\"stages\":[");
+        for (index, stage) in self.stages.iter().enumerate() {
+            if index > 0 {
+                json.push(',');
+            }
+            json.push_str(&stage.to_json());
+        }
+        json.push(']');
+        json.push('}');
+        json
+    }
+}
+
+impl PipelineStage {
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn status(&self) -> &StageStatus {
+        &self.status
+    }
+
+    pub fn metrics(&self) -> &[StageMetric] {
+        &self.metrics
+    }
+
+    fn success(name: &'static str) -> Self {
+        PipelineStage {
+            name,
+            status: StageStatus::Success,
+            metrics: Vec::new(),
+        }
+    }
+
+    fn failed(name: &'static str, message: String) -> Self {
+        PipelineStage {
+            name,
+            status: StageStatus::Failed { message },
+            metrics: Vec::new(),
+        }
+    }
+
+    fn with_metric(mut self, key: &'static str, value: MetricValue) -> Self {
+        self.metrics.push(StageMetric { key, value });
+        self
+    }
+
+    fn to_json(&self) -> String {
+        let mut json = String::new();
+        json.push('{');
+        json.push_str("\"name\":\"");
+        json.push_str(&escape_json_string(self.name));
+        json.push_str("\",");
+        match &self.status {
+            StageStatus::Success => {
+                json.push_str("\"status\":\"ok\"");
+            }
+            StageStatus::Failed { message } => {
+                json.push_str("\"status\":\"error\",");
+                json.push_str("\"message\":\"");
+                json.push_str(&escape_json_string(message));
+                json.push('"');
+            }
+        }
+        json.push(',');
+        json.push_str("\"metrics\":");
+        json.push_str(&metrics_to_json(&self.metrics));
+        json.push('}');
+        json
+    }
+}
+
+impl StageMetric {
+    pub fn key(&self) -> &str {
+        self.key
+    }
+
+    pub fn value(&self) -> &MetricValue {
+        &self.value
+    }
+}
+
+fn metrics_to_json(metrics: &[StageMetric]) -> String {
+    if metrics.is_empty() {
+        return "{}".to_string();
+    }
+    let mut entries = metrics
+        .iter()
+        .map(|metric| (metric.key, &metric.value))
+        .collect::<Vec<_>>();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    let mut json = String::from("{");
+    for (index, (key, value)) in entries.iter().enumerate() {
+        if index > 0 {
+            json.push(',');
+        }
+        json.push('"');
+        json.push_str(&escape_json_string(key));
+        json.push('"');
+        json.push(':');
+        json.push_str(&metric_value_to_json(value));
+    }
+    json.push('}');
+    json
+}
+
+fn metric_value_to_json(value: &MetricValue) -> String {
+    match value {
+        MetricValue::Integer(value) => value.to_string(),
+        MetricValue::Text(text) => format!("\"{}\"", escape_json_string(text)),
+        MetricValue::Bool(flag) => flag.to_string(),
+        MetricValue::List(values) => {
+            let mut entries = values.clone();
+            entries.sort();
+            let mut json = String::from("[");
+            for (index, entry) in entries.iter().enumerate() {
+                if index > 0 {
+                    json.push(',');
+                }
+                json.push('"');
+                json.push_str(&escape_json_string(entry));
+                json.push('"');
+            }
+            json.push(']');
+            json
+        }
+    }
+}
+
+fn escape_json_string(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\u{08}' => escaped.push_str("\\b"),
+            '\u{0C}' => escaped.push_str("\\f"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            ch if (ch as u32) < 0x20 => {
+                use std::fmt::Write;
+                write!(&mut escaped, "\\u{:04X}", ch as u32).expect("json escape write");
+            }
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}


### PR DESCRIPTION
## Summary
- extend the runtime with aggregated trace summaries and a deterministic `net` provider backed by registerable fixtures
- introduce a tooling pipeline snapshot module with unit tests and expose it via a new `--pipeline-json` CLI command
- record parallel backend worker metrics, update roadmap guidance for the current Phase 3 priorities, and expand tests to cover the new surfaces

## Testing
- `cargo fmt`
- `CARGO_NET_OFFLINE=true cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68e13cb3dfa0833098e506e689b71ce3