### PR TITLE
Expand deterministic runtime support and telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ documented entry points to make exploratory reading easier.
   regression tests.
 - [`docs/roadmap/`](docs/roadmap) — Milestones, design notes, and implementation
   plans.
+- [`docs/modules/pipeline.md`](docs/modules/pipeline.md) — CLI entry points for
+  inspecting every compiler stage and exporting pipeline snapshots.
 - [`docs/modules/runtime.md`](docs/modules/runtime.md) — Runtime orchestrator,
   capability providers, and telemetry quickstart.
 - [`examples/`](examples) — Runnable programs referenced throughout the tour

--- a/docs/modules/pipeline.md
+++ b/docs/modules/pipeline.md
@@ -1,0 +1,56 @@
+# Compiler Pipeline Entry Points
+
+> The CLI exposes every stage of the compiler pipeline so tools can plug in
+> without re-implementing compiler internals.
+
+## Overview
+
+`mica` surfaces a set of subcommands and flags that dump intermediate state from
+lexing through code generation. The new `--pipeline-json` flag serialises a
+module's journey through each stage, making it easy to inspect resolver output,
+IR snapshots, and backend telemetry from a single invocation.
+
+## CLI Cheatsheet
+
+| Stage                  | Command snippet                               | Output                      |
+| ---------------------- | --------------------------------------------- | --------------------------- |
+| Tokens                 | `mica --tokens examples/hello.mica`           | Stream of token kinds/lexemes |
+| AST                    | `mica --ast examples/hello.mica`              | Pretty-printed syntax tree  |
+| Resolver + Effects     | `mica --resolve-json examples/hello.mica`     | JSON graph of bindings/effects |
+| Pipeline summary       | `mica --pipeline-json examples/hello.mica`    | JSON object covering every stage |
+| Runtime telemetry      | `mica run examples/hello.mica --trace-json -` | Structured execution trace  |
+
+Use the snippets as building blocks for editor tooling, CI auditing, or data
+pipelines. The JSON outputs are stable, machine-readable structures that map
+cleanly onto the documentation examples.
+
+## Example Workflow
+
+```bash
+mica --pipeline-json examples/concurrency_pipeline.mica > pipeline.json
+jq '.stages.resolve.effects' pipeline.json
+mica run examples/concurrency_pipeline.mica --trace-json trace.json
+jq '.summary.operation_counts' trace.json
+```
+
+The pipeline dump contains per-stage diagnostics, intermediate IR, and emitted
+artifacts. Pair it with the runtime trace to correlate compile-time effects with
+runtime behaviour.
+
+## Integration Tips
+
+1. **Cache intermediate results.** The JSON snapshot includes hashes for each
+   stage, making it easy to determine when downstream tooling needs to refresh
+   its caches.
+2. **Compare stage deltas.** Store previous `--pipeline-json` outputs to diff
+   resolver or IR changes across branches.
+3. **Feed telemetry dashboards.** The runtime trace shares a schema with the
+   pipeline dump, so observability tools can join compile-time and run-time
+   perspectives.
+
+## Next Steps
+
+- Document the JSON schema formally so IDEs can generate typed bindings.
+- Extend `mica run` with `--trace-json <path>` to persist telemetry without
+  piping stdout.
+- Add worked examples to the language tour that reference the pipeline dumps.

--- a/docs/modules/runtime.md
+++ b/docs/modules/runtime.md
@@ -11,23 +11,74 @@ requested capabilities match what the compiler declared.
 
 ## Default Providers
 
-`Runtime::with_default_shims()` registers console, time, filesystem, and
-environment providers so examples and tests run without extra configuration.
+`Runtime::with_default_shims()` registers console, time, filesystem, network,
+and environment providers so examples and tests run without extra configuration.
 Each provider mirrors the capability rows emitted by the compiler:
 
 - **Console (`io`)** – `write_line` emits message events alongside unit results.
 - **Time (`time`)** – `now_millis` returns the current wall-clock time.
 - **Filesystem (`fs`)** – `read_to_string` and `write_string` transfer file
   contents while producing confirmation events.
-- **Environment (`env`)** – `get`, `set`, and `unset` expose environment variable
-  access with predictable clean-up semantics.
+- **Environment (`env`)** – `get`, `set`, and `unset` expose environment
+  variable access with predictable clean-up semantics.
+- **Network (`net`)** – `fetch` resolves requests against pre-registered
+  fixtures without hitting the live network.
+
+### Deterministic Shims for Tests
+
+The host-backed providers are convenient for running real binaries, but tests
+often need reproducible behaviour. `Runtime::with_deterministic_shims()`
+returns a bundle containing in-memory providers that mirror the same
+capabilities without touching the host environment:
+
+- **Deterministic console** captures `write_line` output and can script
+  `read_line` responses.
+- **In-memory filesystem** stores file contents in a hash map so tests can
+  assert on writes and seed reads without touching disk.
+- **Scripted environment** keeps key/value pairs in memory and exposes helper
+  methods to seed fixtures.
+- **Deterministic clock** returns scripted or monotonic timestamps, making it
+  trivial to assert on runtime telemetry.
+
+```rust
+use mica::runtime::{Runtime, RuntimeValue, TaskPlan, TaskSpec};
+
+let bundle = Runtime::with_deterministic_shims()?;
+let runtime = bundle.runtime();
+bundle.console.queue_input("scripted");
+bundle.time.push_time(42);
+
+let spec = TaskSpec::new("main").with_capabilities(["io", "time"]);
+let plan = TaskPlan::new()
+    .invoke("io", "read_line", None)
+    .invoke("time", "now_millis", None);
+
+runtime.spawn(spec, plan);
+runtime.run()?;
+assert_eq!(bundle.time.last_emitted(), Some(43));
+```
 
 ## Telemetry Surface
 
-Every run produces a `RuntimeTrace` that contains ordered events, timestamps, and
-per-task metrics (durations, capability counts, spawned tasks). Use
+Every run produces a `RuntimeTrace` that contains ordered events, timestamps,
+and per-task metrics. The telemetry now captures capability and operation
+counts, as well as the time spent servicing each capability invocation. Use
 `RuntimeTrace::to_json_string()` or `Runtime::run_with_trace_json()` to export
 telemetry for dashboards and tooling.
+
+The JSON summary section has the following shape:
+
+```json
+{
+  "total_tasks": 2,
+  "total_events": 8,
+  "spawned_tasks": 1,
+  "capability_counts": {"io": 2},
+  "operation_counts": {"io::write_line": 2},
+  "capability_durations_micros": {"io": 152},
+  "operation_durations_micros": {"io::write_line": 152}
+}
+```
 
 ## Quick Start
 
@@ -45,3 +96,5 @@ assert_eq!(trace.events().len(), trace.telemetry().len());
 
 Serialise the trace when you need to persist telemetry or feed observability
 pipelines. The stable JSON structure makes it easy to plug into custom tools.
+Pair the deterministic shims with the JSON output to snapshot runtime behaviour
+in tests and continuous integration.

--- a/docs/roadmap/next-step.md
+++ b/docs/roadmap/next-step.md
@@ -7,20 +7,16 @@ runtimes, native code generation, and contributor tooling.
 
 With that context, the next actions should reinforce Phase 3 outcomes:
 
-1. **Broaden deterministic capability providers.** Extend the runtime’s stock
-   shims with filesystem coverage, deterministic network fixtures, and the
-   accompanying smoke tests so compiled programs can exercise richer IO while
-   preserving repeatability.
-2. **Surface richer telemetry.** Emit aggregated runtime summaries (tasks,
-   spawned children, capability usage) and JSON tooling snapshots so IDEs and
-   continuous integration jobs can reason about executions without re-parsing
-   logs.
-3. **Track backend parallelism limits.** Capture worker concurrency and module
-   scheduling metrics from the parallel backend harness to guide scaling
-   experiments and capacity planning.
-4. **Document the pipeline entry points.** Keep CLI references and developer
-   notes aligned with the new `--pipeline-json` command and runtime fixtures so
-   contributors can quickly reproduce the current system behaviour.
+1. **Add process orchestration shims.** Layer scripted subprocess/task providers
+   on top of the deterministic runtime bundle so multi-process programs stay
+   reproducible.
+2. **Export telemetry from the CLI.** Extend `mica run` with opt-in trace output
+   flags and document how downstream tooling can ingest the JSON metrics.
+3. **Tune the parallel backend.** Use the new worker/schedule metrics to profile
+   workspace-sized builds and adjust heuristics before scaling out.
+4. **Publish pipeline walkthroughs.** Turn the documented pipeline entry points
+   into step-by-step guides that show resolver/IR snapshots flowing into editor
+   integrations and automation.
 
 Staying disciplined on these items keeps Phase 3 deliverables aligned: richer
 runtime coverage, observable compiler behaviour, and ergonomic tooling that can

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Project Status — Phase 3 Kickoff
 
-_Last reviewed: 2024-06-25_
+_Last reviewed: 2024-07-01_
 
 The current milestone focuses on stabilising the Phase 3 runtime and backend
 work. The sections below summarise what is healthy today, the verification that
@@ -16,12 +16,15 @@ backs it up, and the immediate priorities for the next iteration.
   they need without duplicating computation.
 - **Backends** – Textual and LLVM renderers are stable, while the native backend
   emits portable C that links with the system toolchain and respects capability
-  contracts.
+  contracts. The parallel driver now records worker utilisation and scheduling
+  timelines to guide optimisation work.
 - **Diagnostics** – Capability misuse, duplicate effects, and missing bindings
   produce focused errors that ship with regression coverage to prevent
   accidental regressions.
 - **Runtime** – Generated binaries thread capability providers through the
   runtime shim, enforcing declared effects before IO or time operations run.
+  Deterministic, in-memory shims unblock regression tests without touching the
+  host environment, and telemetry captures per-capability timings.
 
 ## Verification Snapshot
 
@@ -34,19 +37,20 @@ backs it up, and the immediate priorities for the next iteration.
 
 ## Near-Term Priorities
 
-1. Expand the capability provider library (filesystem, networking, process
-   orchestration) so runtime-aware binaries cover more scenarios out of the box.
-2. Emit structured runtime telemetry that feeds the forthcoming observability
-   and tooling workstreams.
-3. Exercise the parallel backend harness against multi-module workspaces to
-   profile contention and tune scheduling heuristics.
-4. Build CLI conveniences for the resolver and IR JSON dumps so editors and
-   automation can consume the data without custom parsers.
+1. Introduce process and task-orchestration providers so sandboxed binaries can
+   spawn scripted subprocesses without leaving the deterministic surface.
+2. Feed the richer runtime telemetry into CLI exporters (e.g. `mica run`
+   `--trace-json <path>`) and document downstream ingestion patterns.
+3. Use the new parallel compile metrics to tune worker heuristics against
+   workspace-sized module sets and surface the results in the docs.
+4. Extend the freshly documented pipeline entry points with end-to-end
+   walkthroughs that show how resolver and IR snapshots integrate with editor
+   tooling.
 
 ## Risks & Watch Items
 
-- **Provider coverage** – Console/time shims ship today; widening the surface
-  without additional regression coverage risks unexpected behaviour.
+- **Provider coverage** – The deterministic shims reduce IO risk, but adding
+  process orchestration requires careful sandboxing and regression coverage.
 - **Coverage portability** – Test coverage reporting remains paused until a
   cross-platform workflow is identified that does not require bespoke tooling.
 - **Testing debt** – Parser and resolver fuzzing is still outstanding and should

--- a/docs/status_summary.md
+++ b/docs/status_summary.md
@@ -1,6 +1,6 @@
 # Phase 3 Kickoff Status
 
-_Last refreshed: 2024-06-25_
+_Last refreshed: 2024-07-01_
 
 This summary condenses the current Phase 3 health report for quick scanning. It
 highlights what is stable, how we validate it, and where contributors can have
@@ -26,8 +26,10 @@ the most impact next.
   expressions, effect rows, return behaviour, and purity reporting.
 - The native backend emits portable C for typed IR, including record aggregates,
   and drives the system toolchain to produce runnable binaries.
-- The runtime orchestrator binds IO/time providers and validates capability
-  coverage before native binaries execute.
+- The runtime orchestrator binds IO/time providers, now including deterministic
+  in-memory shims, and validates capability coverage before native binaries
+  execute. Telemetry captures per-capability counts and durations for
+  downstream analysis.
 
 ### Tooling and Developer Experience
 - The `mica` CLI exposes lexing, resolving, lowering, IR dumps, LLVM previews,
@@ -59,18 +61,18 @@ the most impact next.
 
 ## Next Focus Areas
 
-1. **Provider breadth** – Extend runtime shims beyond console/time to cover
-   filesystem and networking scenarios.
-2. **Runtime telemetry** – Emit structured execution events from generated
-   binaries for downstream observability tooling.
-3. **Parallel backend scaling** – Stress the parallel compile driver across
-   workspace-sized module sets and instrument contention hotspots.
-4. **Tooling APIs** – Layer higher-level CLI entry points over the resolver and
-   IR JSON dumps to unblock IDE integrations and automated audits.
+1. **Process providers** – Introduce scripted process/task orchestration so the
+   deterministic runtime can model multi-process workloads safely.
+2. **Telemetry exporters** – Wire the richer runtime metrics into CLI flags and
+   document how downstream tooling consumes the JSON traces.
+3. **Parallel backend scaling** – Use the new worker metrics to tune scheduling
+   heuristics on workspace-sized module sets and publish guidance.
+4. **Pipeline documentation** – Expand the freshly documented pipeline entry
+   points with end-to-end walkthroughs for editor integrations and audits.
 
 ## Watch Items
 
-- Runtime provider coverage is intentionally narrow; broaden it only with new
-  smoke tests to avoid surprising consumers.
+- Runtime provider coverage still requires care: process orchestration must ship
+  with deterministic fixtures and smoke tests to avoid surprising consumers.
 - Evaluate portable coverage collectors that work across the CI matrix so we can
   reintroduce reporting without bespoke tooling.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -72,12 +72,30 @@ pub struct ParallelCompileMetrics {
     pub modules: Vec<ModuleCompileMetrics>,
     pub worker_count: usize,
     pub scheduled_modules: usize,
+    pub worker_metrics: Vec<WorkerMetrics>,
+    pub schedule: Vec<ScheduleEntry>,
 }
 
 #[derive(Debug, Clone)]
 pub struct ModuleCompileMetrics {
     pub module: String,
     pub duration: Duration,
+    pub worker_index: usize,
+    pub start_offset: Duration,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkerMetrics {
+    pub worker_index: usize,
+    pub processed_modules: usize,
+    pub busy_duration: Duration,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScheduleEntry {
+    pub module: String,
+    pub worker_index: usize,
+    pub start_offset: Duration,
 }
 
 pub fn run_parallel<B>(
@@ -89,6 +107,19 @@ where
     B: Backend + Sync,
     B::Output: Send + 'static,
 {
+    #[derive(Default, Clone)]
+    struct ModuleRecord {
+        worker_index: usize,
+        duration: Duration,
+        start_offset: Duration,
+    }
+
+    #[derive(Default)]
+    struct WorkerAccumulator {
+        processed_modules: usize,
+        busy_duration: Duration,
+    }
+
     if modules.is_empty() {
         return Ok(ParallelCompileReport {
             outputs: Vec::new(),
@@ -100,9 +131,9 @@ where
     output_slots.resize_with(modules.len(), || None);
     let outputs: Arc<Mutex<Vec<Option<B::Output>>>> = Arc::new(Mutex::new(output_slots));
 
-    let mut duration_slots = Vec::with_capacity(modules.len());
-    duration_slots.resize_with(modules.len(), || None);
-    let durations: Arc<Mutex<Vec<Option<Duration>>>> = Arc::new(Mutex::new(duration_slots));
+    let mut record_slots = Vec::with_capacity(modules.len());
+    record_slots.resize_with(modules.len(), || None);
+    let records: Arc<Mutex<Vec<Option<ModuleRecord>>>> = Arc::new(Mutex::new(record_slots));
     let error: Arc<Mutex<Option<BackendError>>> = Arc::new(Mutex::new(None));
     let options = options.clone();
     let start = Instant::now();
@@ -113,14 +144,20 @@ where
         .min(modules.len())
         .max(1);
     let next_index = Arc::new(AtomicUsize::new(0));
+    let worker_accumulators: Arc<Vec<Mutex<WorkerAccumulator>>> = Arc::new(
+        (0..worker_count)
+            .map(|_| Mutex::new(WorkerAccumulator::default()))
+            .collect(),
+    );
 
     std::thread::scope(|scope| {
-        for _ in 0..worker_count {
+        for worker_index in 0..worker_count {
             let outputs = Arc::clone(&outputs);
-            let durations = Arc::clone(&durations);
+            let records = Arc::clone(&records);
             let error = Arc::clone(&error);
             let options = options.clone();
             let next_index = Arc::clone(&next_index);
+            let worker_accumulators = Arc::clone(&worker_accumulators);
             scope.spawn(move || {
                 loop {
                     if error.lock().unwrap().is_some() {
@@ -133,11 +170,22 @@ where
                     }
 
                     let module = &modules[index];
+                    let dispatch_offset = start.elapsed();
                     let module_start = Instant::now();
                     match backend.compile(module, &options) {
                         Ok(result) => {
-                            durations.lock().unwrap()[index] = Some(module_start.elapsed());
+                            let duration = module_start.elapsed();
+                            records.lock().unwrap()[index] = Some(ModuleRecord {
+                                worker_index,
+                                duration,
+                                start_offset: dispatch_offset,
+                            });
                             outputs.lock().unwrap()[index] = Some(result);
+                            let mut worker_guard = worker_accumulators[worker_index]
+                                .lock()
+                                .expect("worker metrics poisoned");
+                            worker_guard.processed_modules += 1;
+                            worker_guard.busy_duration += duration;
                         }
                         Err(err) => {
                             let mut guard = error.lock().unwrap();
@@ -162,7 +210,7 @@ where
         .map(|entry| entry.take().expect("missing backend output"))
         .collect::<Vec<_>>();
 
-    let duration_guard = durations.lock().unwrap();
+    let record_guard = records.lock().unwrap();
     let module_metrics = modules
         .iter()
         .enumerate()
@@ -172,7 +220,41 @@ where
             } else {
                 module.name.join("::")
             },
-            duration: duration_guard[index].unwrap_or_default(),
+            duration: record_guard[index]
+                .as_ref()
+                .map(|record| record.duration)
+                .unwrap_or_default(),
+            worker_index: record_guard[index]
+                .as_ref()
+                .map(|record| record.worker_index)
+                .unwrap_or_default(),
+            start_offset: record_guard[index]
+                .as_ref()
+                .map(|record| record.start_offset)
+                .unwrap_or_default(),
+        })
+        .collect::<Vec<_>>();
+
+    let mut schedule = module_metrics
+        .iter()
+        .map(|metrics| ScheduleEntry {
+            module: metrics.module.clone(),
+            worker_index: metrics.worker_index,
+            start_offset: metrics.start_offset,
+        })
+        .collect::<Vec<_>>();
+    schedule.sort_by_key(|entry| entry.start_offset);
+
+    let worker_metrics = worker_accumulators
+        .iter()
+        .enumerate()
+        .map(|(index, accumulator)| {
+            let guard = accumulator.lock().expect("worker metrics poisoned");
+            WorkerMetrics {
+                worker_index: index,
+                processed_modules: guard.processed_modules,
+                busy_duration: guard.busy_duration,
+            }
         })
         .collect::<Vec<_>>();
 
@@ -181,6 +263,8 @@ where
         modules: module_metrics,
         worker_count,
         scheduled_modules: modules.len(),
+        worker_metrics,
+        schedule,
     };
 
     Ok(ParallelCompileReport { outputs, metrics })


### PR DESCRIPTION
## Summary
- add a deterministic runtime bundle with in-memory providers and richer telemetry output so tests can assert runtime behaviour
- record per-worker timing metrics in the parallel backend and add coverage for the new schedule reporting
- document pipeline entry points and refresh the status/roadmap guidance for the updated runtime and backend surfaces
- refactor task telemetry construction to group timing and aggregate metrics so the runtime stays within clippy limits

## Testing
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68e1a461226c83308431d70120f3af72