### PR TITLE
Run cargo fmt to fix formatting issues

### DIFF
--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -160,14 +160,14 @@ fn function_signature(
     record_names: &RecordNameMap,
 ) -> BackendResult<String> {
     let mut signature = String::new();
-    
+
     // Special case: main function in C must return int
     let ret_type = if function.name == "main" {
         "int".to_string()
     } else {
         c_type_return(module, function.ret_type, record_names)
     };
-    
+
     write!(signature, "{} {}(", ret_type, mangle_name(&function.name)).unwrap();
 
     for (index, param) in function.params.iter().enumerate() {

--- a/src/tests/backend_tests.rs
+++ b/src/tests/backend_tests.rs
@@ -625,12 +625,13 @@ fn parallel_backend_reports_metrics_for_many_modules() {
 
     assert_eq!(report.outputs.len(), modules.len());
     assert_eq!(report.metrics.modules.len(), modules.len());
-    
+
     // Use the actual recommended_worker_count logic which reserves headroom
     let available = std::thread::available_parallelism()
         .map(|count| count.get())
         .unwrap_or(1);
-    let expected_workers = backend::recommended_worker_count_with_available(modules.len(), available);
+    let expected_workers =
+        backend::recommended_worker_count_with_available(modules.len(), available);
     assert_eq!(report.metrics.worker_count, expected_workers);
     assert_eq!(report.metrics.scheduled_modules, modules.len());
     assert!(report.metrics.total_duration >= delay);


### PR DESCRIPTION
## Summary
- apply rustfmt formatting in native backend and backend tests

## Testing
- cargo fmt --all -- --check

------
https://chatgpt.com/codex/tasks/task_e_68e1fb4e7e3c833083933638dd29b25e